### PR TITLE
fix: 更新 Docker 基础镜像避免 buster 源失效

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# 使用Node.js v16.19.0作为基础镜像
-FROM node:16.19.0-slim AS builder
+# 使用受支持的 Node LTS + Debian bookworm，避免 buster 源失效
+FROM node:20-bookworm-slim AS builder
 
 # 设置工作目录
 WORKDIR /home
@@ -22,7 +22,7 @@ RUN cd vender/cloud189-sdk && yarn build
 RUN yarn build
 
 # 构建生产版本
-FROM node:16.19.0-slim AS production
+FROM node:20-bookworm-slim AS production
 
 # 设置工作目录
 WORKDIR /home


### PR DESCRIPTION
## 变更说明
- 将 Docker 基础镜像从 `node:16.19.0-slim` 切换为 `node:20-bookworm-slim`
- 避免 Debian buster 源失效导致 `apt-get update` 404

## 背景
GitHub Actions Docker 构建在生产阶段执行 `apt-get update` 时命中 buster 仓库 404，导致镜像构建失败。

## 验证
- `docker build --platform linux/amd64 -t cloud189-auto-save:test .`
- 本地构建通过，`apt-get update` 已正常走到 bookworm 源