### PR TITLE
feat: add standalone Emby proxy port and family signature fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /home/strm
 # 挂载点
 VOLUME ["/home/data", "/home/strm"]
 # 暴露端口
-EXPOSE 3000
+EXPOSE 3000 8097
 
 # 启动命令
 CMD ["yarn", "start"]

--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,7 @@ docker run -d \
   -v /yourpath/data:/home/data \
   -v /yourpath/strm:/home/strm \
   -p 3000:3000 \
+  -p 8097:8097 \
   --restart unless-stopped \
   --name cloud189 \
   -e PUID=0 \
@@ -118,6 +119,7 @@ docker run -d \
   xia1307/cloud189-auto-save
   ```
 注意: `yourpath`请替换为你宿主机的目录; 如果不需要strm功能, 可以不挂载strm目录, 允许配置PUID和PGID, 默认0。若日志出现 `InvalidSessionKey` / `check ip error`，通常是双栈网络下 IPv4/IPv6 出口切换导致，建议保留 `-e DNS_LOOKUP_IP_VERSION=ipv4`。
+如需使用 Emby 独立反代端口，请保留 `-p 8097:8097`，并在系统设置中开启 Emby 反代。
 
 ### 使用 GHCR 镜像
 
@@ -126,6 +128,7 @@ docker run -d \
   -v /yourpath/data:/home/data \
   -v /yourpath/strm:/home/strm \
   -p 3000:3000 \
+  -p 8097:8097 \
   --restart unless-stopped \
   --name cloud189 \
   -e PUID=0 \

--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,88 @@ const { LazyShareStrmService } = require('./services/lazyShareStrm');
 const { OrganizerService } = require('./services/organizer');
 const { AutoSeriesService } = require('./services/autoSeries');
 
-const app = express();
-app.use(cors({
-    origin: '*', // 允许所有来源
+const appPort = Number(process.env.PORT || 3000);
+let embyStandaloneProxyServer = null;
+const corsOptions = {
+    origin: '*',
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'x-api-key'],
     credentials: true
-}));
+};
+
+const getStandaloneEmbyProxyPort = () => {
+    const configuredPort = Number(
+        ConfigService.getConfigValue('emby.proxy.port')
+        || process.env.EMBY_PROXY_PORT
+        || 8097
+    );
+    return Number.isInteger(configuredPort) && configuredPort > 0 ? configuredPort : 8097;
+};
+
+const closeStandaloneEmbyProxyServer = async () => {
+    if (!embyStandaloneProxyServer) {
+        return;
+    }
+
+    const server = embyStandaloneProxyServer;
+    embyStandaloneProxyServer = null;
+    await new Promise((resolve) => {
+        server.close((error) => {
+            if (error) {
+                console.error('关闭 Emby 独立反代端口失败:', error.message);
+            } else {
+                console.log('Emby 独立反代端口已关闭');
+            }
+            resolve();
+        });
+    });
+};
+
+const createStandaloneEmbyProxyApp = (embyService) => {
+    const proxyApp = express();
+    proxyApp.use(cors(corsOptions));
+    proxyApp.use(async (req, res) => {
+        await embyService.handleProxyRequest(req, res, { basePath: '' });
+    });
+    return proxyApp;
+};
+
+const syncStandaloneEmbyProxyServer = async (embyService) => {
+    const shouldEnableStandaloneProxy = !!ConfigService.getConfigValue('emby.proxy.enable');
+    const proxyPort = getStandaloneEmbyProxyPort();
+
+    if (!shouldEnableStandaloneProxy) {
+        await closeStandaloneEmbyProxyServer();
+        return;
+    }
+
+    if (proxyPort === appPort) {
+        console.warn(`Emby 独立反代端口 ${proxyPort} 与主服务端口冲突，已跳过启动`);
+        await closeStandaloneEmbyProxyServer();
+        return;
+    }
+
+    if (embyStandaloneProxyServer) {
+        const currentPort = embyStandaloneProxyServer.address()?.port;
+        if (currentPort === proxyPort) {
+            return;
+        }
+        await closeStandaloneEmbyProxyServer();
+    }
+
+    const proxyApp = createStandaloneEmbyProxyApp(embyService);
+    await new Promise((resolve, reject) => {
+        const server = proxyApp.listen(proxyPort, () => {
+            embyStandaloneProxyServer = server;
+            console.log(`Emby 独立反代运行在 http://localhost:${proxyPort}`);
+            resolve();
+        });
+        server.once('error', reject);
+    });
+};
+
+const app = express();
+app.use(cors(corsOptions));
 app.use(express.json());
 
 app.use(session({
@@ -169,7 +244,7 @@ AppDataSource.initialize().then(async () => {
     await SchedulerService.initStrmConfigJobs(strmConfigRepo, strmConfigService);
 
     app.use('/emby-proxy', async (req, res) => {
-        await embyService.handleProxyRequest(req, res);
+        await embyService.handleProxyRequest(req, res, { basePath: '/emby-proxy' });
     });
     
     // 账号相关API
@@ -1002,16 +1077,21 @@ AppDataSource.initialize().then(async () => {
 
     // 保存媒体配置
     app.post('/api/settings/media', async (req, res) => {
-        const settings = req.body;
-        // 如果cloudSaver的配置变更 就清空cstoken.json
-        if (settings.cloudSaver?.baseUrl != ConfigService.getConfigValue('cloudSaver.baseUrl')
-        || settings.cloudSaver?.username != ConfigService.getConfigValue('cloudSaver.username')
-        || settings.cloudSaver?.password != ConfigService.getConfigValue('cloudSaver.password')
-    ) {
-            clearCloudSaverToken();
+        try {
+            const settings = req.body;
+            // 如果cloudSaver的配置变更 就清空cstoken.json
+            if (settings.cloudSaver?.baseUrl != ConfigService.getConfigValue('cloudSaver.baseUrl')
+            || settings.cloudSaver?.username != ConfigService.getConfigValue('cloudSaver.username')
+            || settings.cloudSaver?.password != ConfigService.getConfigValue('cloudSaver.password')
+        ) {
+                clearCloudSaverToken();
+            }
+            ConfigService.setConfig(settings)
+            await syncStandaloneEmbyProxyServer(embyService);
+            res.json({success: true, data: null})
+        } catch (error) {
+            res.json({success: false, error: error.message})
         }
-        ConfigService.setConfig(settings)
-        res.json({success: true, data: null})
     })
 
     app.post('/api/settings/regex-presets', async (req, res) => {
@@ -1298,9 +1378,13 @@ AppDataSource.initialize().then(async () => {
     // 初始化cloudsaver
     setupCloudSaverRoutes(app);
     // 启动服务器
-    const port = process.env.PORT || 3000;
-    app.listen(port, () => {
-        console.log(`服务器运行在 http://localhost:${port}`);
+    app.listen(appPort, async () => {
+        console.log(`服务器运行在 http://localhost:${appPort}`);
+        try {
+            await syncStandaloneEmbyProxyServer(embyService);
+        } catch (error) {
+            console.error('启动 Emby 独立反代端口失败:', error.message);
+        }
     });
 }).catch(error => {
     console.error('数据库连接失败:', error);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -949,7 +949,9 @@
                             <input type="text" id="embyServer" placeholder="例如: http://localhost:8096">
                             <label for="embyApiKey">API Key</label>
                             <input type="text" id="embyApiKey" placeholder="Emby API Key">
-                            <small class="form-text">启用后可通过 <code>/emby-proxy</code> 访问 Emby，播放请求会优先尝试 302 到天翼直链；其余请求会回源到 Emby。</small>
+                            <label for="embyProxyPort">独立反代端口</label>
+                            <input type="number" id="embyProxyPort" placeholder="例如: 8097">
+                            <small class="form-text">启用后除了可通过 <code>/emby-proxy</code> 访问外，还会额外启动一个独立端口（默认 <code>8097</code>）直接反代 Emby 根路径，播放请求会优先尝试 302 到天翼直链；其余请求会回源到 Emby。</small>
                         </div>
                     </div>
                 </div>
@@ -1249,7 +1251,7 @@
                 </div>
                 <div class="form-group">
                     <label for="subscriptionResourceShareLink">分享链接</label>
-                    <input type="text" id="subscriptionResourceShareLink" required placeholder="支持自动解析访问码">
+                    <input type="text" id="subscriptionResourceShareLink" required placeholder="支持分享链接、订阅码或 uuid，自动解析访问码">
                 </div>
                 <div class="form-group">
                     <label for="subscriptionResourceAccessCode">访问码</label>

--- a/src/public/js/media.js
+++ b/src/public/js/media.js
@@ -22,7 +22,8 @@ async function saveMediaSettings() {
             serverUrl: document.getElementById('embyServer').value,
             apiKey: document.getElementById('embyApiKey').value,
             proxy: {
-                enable: enableEmbyProxy
+                enable: enableEmbyProxy,
+                port: parseInt(document.getElementById('embyProxyPort').value) || 8097
             }
         },
         cloudSaver: {

--- a/src/public/js/settings.js
+++ b/src/public/js/settings.js
@@ -80,6 +80,7 @@ async function loadSettings() {
             document.getElementById('enableEmbyProxy').checked = settings.emby?.proxy?.enable || false;
             document.getElementById('embyServer').value = settings.emby?.serverUrl || '';
             document.getElementById('embyApiKey').value = settings.emby?.apiKey || '';
+            document.getElementById('embyProxyPort').value = settings.emby?.proxy?.port || 8097;
 
             // tg机器人设置
             document.getElementById('enableTgBot').checked = settings.telegram?.bot?.enable || false;

--- a/src/services/ConfigService.js
+++ b/src/services/ConfigService.js
@@ -86,7 +86,8 @@ class ConfigService {
         serverUrl: '',
         apiKey: '',
         proxy: {
-          enable: false
+          enable: false,
+          port: 8097
         }
       },
       cloudSaver: {

--- a/src/services/emby.js
+++ b/src/services/emby.js
@@ -34,8 +34,11 @@ class EmbyService {
         this.proxyEnabled = !!ConfigService.getConfigValue('emby.proxy.enable');
     }
 
-    getProxyBasePath() {
-        return '/emby-proxy';
+    getProxyBasePath(options = {}) {
+        if (typeof options === 'string') {
+            return options || '';
+        }
+        return options.basePath || '/emby-proxy';
     }
 
     isProxyEnabled() {
@@ -43,15 +46,18 @@ class EmbyService {
         return this.proxyEnabled;
     }
 
-    async handleProxyRequest(req, res) {
+    async handleProxyRequest(req, res, options = {}) {
         this._refreshConfig();
         if (!this.embyUrl) {
             res.status(503).json({ success: false, error: 'Emby 服务器地址未配置' });
             return;
         }
 
-        const proxyBasePath = this.getProxyBasePath();
-        const relativePath = (req.originalUrl || req.url || '').replace(new RegExp(`^${proxyBasePath}`), '') || '/';
+        const proxyBasePath = this.getProxyBasePath(options);
+        const currentUrl = req.originalUrl || req.url || '/';
+        const relativePath = proxyBasePath
+            ? (currentUrl.replace(new RegExp(`^${proxyBasePath}`), '') || '/')
+            : currentUrl || '/';
 
         if (this.proxyEnabled && this._isPlaybackRequest(relativePath)) {
             try {
@@ -66,7 +72,7 @@ class EmbyService {
             }
         }
 
-        await this._forwardToEmby(req, res, relativePath);
+        await this._forwardToEmby(req, res, relativePath, proxyBasePath);
     }
 
 
@@ -226,7 +232,7 @@ class EmbyService {
         return upstream.toString();
     }
 
-    async _forwardToEmby(req, res, relativePath) {
+    async _forwardToEmby(req, res, relativePath, proxyBasePath = '/emby-proxy') {
         const targetUrl = this._buildProxyTargetUrl(relativePath);
         const headers = {
             ...req.headers,
@@ -256,7 +262,7 @@ class EmbyService {
                     continue;
                 }
                 if (key.toLowerCase() === 'location') {
-                    res.setHeader(key, this._rewriteProxyLocation(String(value)));
+                    res.setHeader(key, this._rewriteProxyLocation(String(value), proxyBasePath));
                     continue;
                 }
                 res.setHeader(key, value);
@@ -270,13 +276,15 @@ class EmbyService {
         upstream.pipe(res);
     }
 
-    _rewriteProxyLocation(location) {
+    _rewriteProxyLocation(location, proxyBasePath = '/emby-proxy') {
         if (!location || !this.embyUrl) {
             return location;
         }
-        const proxyBasePath = this.getProxyBasePath();
         if (location.startsWith(this.embyUrl)) {
             return `${proxyBasePath}${location.substring(this.embyUrl.length) || '/'}`;
+        }
+        if (location.startsWith('/') && proxyBasePath && !location.startsWith(proxyBasePath)) {
+            return `${proxyBasePath}${location}`;
         }
         return location;
     }

--- a/src/utils/Cloud189Utils.js
+++ b/src/utils/Cloud189Utils.js
@@ -1,76 +1,106 @@
 class Cloud189Utils {
-    // 解析分享码
-    static parseShareCode(shareLink) {
-        // 解析分享链接
-        let shareCode;
+    static SHARE_CODE_PATTERN = /^(?:uuid)?[a-zA-Z0-9_-]{8,}$/;
+
+    static _decodeShareText(shareText = '') {
+        try {
+            return decodeURIComponent(shareText);
+        } catch (error) {
+            return shareText;
+        }
+    }
+
+    static _normalizeShareText(shareText = '') {
+        return this._decodeShareText(String(shareText || '')).replace(/\s/g, '');
+    }
+
+    static _extractShareCodeFromUrl(shareLink) {
         const shareUrl = new URL(shareLink);
+        let shareCode = '';
         if (shareUrl.origin.includes('content.21cn.com')) {
-            // 处理订阅链接
-            const params = new URLSearchParams(shareUrl.hash.split('?')[1]);
-            shareCode = params.get('shareCode');
+            const hashQuery = shareUrl.hash.includes('?') ? shareUrl.hash.split('?')[1] : '';
+            const hashParams = new URLSearchParams(hashQuery);
+            shareCode = hashParams.get('shareCode') || shareUrl.searchParams.get('shareCode');
         } else if (shareUrl.pathname === '/web/share') {
             shareCode = shareUrl.searchParams.get('code');
         } else if (shareUrl.pathname.startsWith('/t/')) {
             shareCode = shareUrl.pathname.split('/').pop();
-        }else if (shareUrl.hash && shareUrl.hash.includes('/t/')) {
-            shareCode = shareUrl.hash.split('/').pop();
-        }else if (shareUrl.pathname.includes('share.html')) {
-            // 其他可能的 share.html 格式
+        } else if (shareUrl.hash && shareUrl.hash.includes('/t/')) {
+            shareCode = shareUrl.hash.split('/').pop()?.split('?')[0];
+        } else if (shareUrl.pathname.includes('share.html')) {
             const hashParts = shareUrl.hash.split('/');
-            shareCode = hashParts[hashParts.length - 1];
+            shareCode = hashParts[hashParts.length - 1]?.split('?')[0];
         }
-        
+        return shareCode || '';
+    }
+
+    static _buildSubscriptionShareUrl(shareCode) {
+        return `https://content.21cn.com/h5/#/home?shareCode=${encodeURIComponent(shareCode)}`;
+    }
+
+    // 解析分享码
+    static parseShareCode(shareLink) {
+        const normalizedShareLink = this._normalizeShareText(shareLink);
+        if (this.SHARE_CODE_PATTERN.test(normalizedShareLink)) {
+            return normalizedShareLink;
+        }
+
+        let shareCode = '';
+        try {
+            shareCode = this._extractShareCodeFromUrl(normalizedShareLink);
+        } catch (error) {
+            throw new Error('无效的分享链接');
+        }
+
         if (!shareCode) throw new Error('无效的分享链接');
         return shareCode
     }
 
     static parseCloudShare(shareText) {
-        // 移除所有空格
-        shareText = shareText.replace(/\s/g, '');
-        shareText = decodeURIComponent(shareText);
-        // 提取基本URL和访问码
+        shareText = this._normalizeShareText(shareText);
         let url = '';
         let accessCode = '';
-        
-        // 匹配访问码的几种常见格式
+
         const accessCodePatterns = [
-            /[（(]访问码[：:]\s*([a-zA-Z0-9]{4})[)）]/,  // （访问码：xxxx）
-            /[（(]提取码[：:]\s*([a-zA-Z0-9]{4})[)）]/,  // （提取码：xxxx）
-            /访问码[：:]\s*([a-zA-Z0-9]{4})/,           // 访问码：xxxx
-            /提取码[：:]\s*([a-zA-Z0-9]{4})/,           // 提取码：xxxx
-            /[（(]([a-zA-Z0-9]{4})[)）]/                // （xxxx）
+            /[（(]访问码[：:]\s*([a-zA-Z0-9]{4})[)）]/,
+            /[（(]提取码[：:]\s*([a-zA-Z0-9]{4})[)）]/,
+            /访问码[：:]\s*([a-zA-Z0-9]{4})/,
+            /提取码[：:]\s*([a-zA-Z0-9]{4})/,
+            /[（(]([a-zA-Z0-9]{4})[)）]/
         ];
-        
-        // 尝试匹配访问码
+
         for (const pattern of accessCodePatterns) {
             const match = shareText.match(pattern);
             if (match) {
                 accessCode = match[1];
-                // 从原文本中移除访问码部分
                 shareText = shareText.replace(match[0], '');
                 break;
             }
         }
-        
-        // 提取URL - 支持两种格式
-        const urlPatterns = [
-            /(https?:\/\/cloud\.189\.cn\/web\/share\?[^\s]+)/,     // web/share格式
-            /(https?:\/\/cloud\.189\.cn\/t\/[a-zA-Z0-9]+)/,        // t/xxx格式
-            /(https?:\/\/h5\.cloud\.189\.cn\/share\.html#\/t\/[a-zA-Z0-9]+)/, // h5分享格式
-            /(https?:\/\/[^/]+\/web\/share\?[^\s]+)/,              // 其他域名的web/share格式
-            /(https?:\/\/[^/]+\/t\/[a-zA-Z0-9]+)/,                 // 其他域名的t/xxx格式
-            /(https?:\/\/[^/]+\/share\.html[^\s]*)/,               // share.html格式
-            /(https?:\/\/content\.21cn\.com[^\s]+)/                // 订阅链接格式
-        ];
-    
-        for (const pattern of urlPatterns) {
-            const urlMatch = shareText.match(pattern);
-            if (urlMatch) {
-                url = urlMatch[1];
-                break;
+
+        shareText = this._normalizeShareText(shareText);
+
+        if (this.SHARE_CODE_PATTERN.test(shareText)) {
+            url = this._buildSubscriptionShareUrl(shareText);
+        } else {
+            const urlPatterns = [
+                /(https?:\/\/cloud\.189\.cn\/web\/share\?[^\s]+)/,
+                /(https?:\/\/cloud\.189\.cn\/t\/[a-zA-Z0-9_-]+)/,
+                /(https?:\/\/h5\.cloud\.189\.cn\/share\.html#\/t\/[a-zA-Z0-9_-]+)/,
+                /(https?:\/\/[^/]+\/web\/share\?[^\s]+)/,
+                /(https?:\/\/[^/]+\/t\/[a-zA-Z0-9_-]+)/,
+                /(https?:\/\/[^/]+\/share\.html[^\s]*)/,
+                /(https?:\/\/content\.21cn\.com[^\s]+)/
+            ];
+
+            for (const pattern of urlPatterns) {
+                const urlMatch = shareText.match(pattern);
+                if (urlMatch) {
+                    url = urlMatch[1];
+                    break;
+                }
             }
         }
-        
+
         return {
             url: url,
             accessCode: accessCode


### PR DESCRIPTION
## Summary
- add a standalone Emby reverse proxy port (default `8097`) alongside `/emby-proxy`
- make Emby proxy config support a dedicated port and dynamic startup/shutdown on settings save
- improve share link parsing utilities
- update Docker/README examples for the standalone Emby proxy port
- bump the `vender/cloud189-sdk` submodule pointer to include the family signature fix

## Verification
- cd vender/cloud189-sdk && yarn build
- yarn build

## Dependency
- Depends on 1307super/cloud189-sdk#1

## Notes
The submodule update fixes family cloud requests failing with `InvalidSignature` / `accessTokenSignature is not match`.
