### PR TITLE
fix: 收紧设置/账号凭据脱敏与本地加密落库

### DIFF
--- a/frontend/src/components/tabs/AccountTab.tsx
+++ b/frontend/src/components/tabs/AccountTab.tsx
@@ -27,8 +27,8 @@ interface Account {
   cloudStrmPrefix: string | null;
   localStrmPrefix: string | null;
   embyPathReplace: string | null;
-  password?: string;
-  cookies?: string;
+  hasPassword?: boolean;
+  hasCookies?: boolean;
 }
 
 interface StorageSummary {
@@ -183,8 +183,8 @@ const AccountTab: React.FC = () => {
     setEditingAccount(account);
     setFormData({
       username: account.username,
-      password: '', // Don't fill password for security
-      cookies: account.cookies || '',
+      password: '', // 留空表示不覆盖已保存密码
+      cookies: '', // 留空表示不覆盖已保存 Cookie
       alias: account.alias || '',
       accountType: account.accountType || 'personal',
       familyId: account.familyId || '',
@@ -344,7 +344,8 @@ const AccountTab: React.FC = () => {
       toast.warning('用户名不能为空');
       return;
     }
-    if (!formData.password && !formData.cookies) {
+    // 新建必须有凭据；编辑允许都空（后端保留旧值）
+    if (!editingAccount && !formData.password && !formData.cookies) {
       toast.warning('密码和Cookie不能同时为空');
       return;
     }
@@ -683,23 +684,29 @@ const AccountTab: React.FC = () => {
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium text-slate-700">密码</label>
-              <input 
-                type="password" 
+              <input
+                type="password"
                 value={formData.password}
                 onChange={e => setFormData({...formData, password: e.target.value})}
-                className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20" 
+                placeholder={editingAccount?.hasPassword ? '已保存密码；留空不覆盖' : '账号密码'}
+                className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">Cookie (可选)</label>
-            <textarea 
-              rows={3} 
+            <textarea
+              rows={3}
               value={formData.cookies}
               onChange={e => setFormData({...formData, cookies: e.target.value})}
-              className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20" 
+              placeholder={editingAccount?.hasCookies ? '已保存 Cookie；留空不覆盖' : '可选 Cookie'}
+              className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
             />
-            <p className="text-xs text-slate-500">密码和 Cookie 至少填写一个，如果都填写，则只有账号密码生效。</p>
+            <p className="text-xs text-slate-500">
+              {editingAccount
+                ? '编辑时密码/Cookie 留空表示不修改；若都填写则优先使用密码。'
+                : '密码和 Cookie 至少填写一个，如果都填写，则只有账号密码生效。'}
+            </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -31,6 +31,7 @@ interface MediaSettings {
     enable: boolean;
     serverUrl: string;
     apiKey: string;
+    hasApiKey?: boolean;
     webhookSecret: string;
     hasWebhookSecret?: boolean;
     allowUnauthenticatedWebhook: boolean;
@@ -48,6 +49,7 @@ interface MediaSettings {
     baseUrl: string;
     username: string;
     password: string;
+    hasPassword?: boolean;
   };
   hdhive: {
     enabled: boolean;
@@ -58,11 +60,13 @@ interface MediaSettings {
   tmdb: {
     enableScraper: boolean;
     tmdbApiKey: string;
+    hasTmdbApiKey?: boolean;
   };
   openai: {
     enable: boolean;
     baseUrl: string;
     apiKey: string;
+    hasApiKey?: boolean;
     model: string;
     flowControlEnabled: boolean;
     rename: {
@@ -74,6 +78,7 @@ interface MediaSettings {
     enable: boolean;
     baseUrl: string;
     apiKey: string;
+    hasApiKey?: boolean;
   };
   organizer: {
     categories: {
@@ -108,24 +113,26 @@ const initialSettings: MediaSettings = {
     enable: false,
     serverUrl: '',
     apiKey: '',
+    hasApiKey: false,
     webhookSecret: '',
     hasWebhookSecret: false,
     allowUnauthenticatedWebhook: false,
     proxy: { enable: false, port: 8097 },
     prewarm: { enable: false, sessionPollIntervalMs: 30000, dedupeTtlMs: 300000 }
   },
-  cloudSaver: { baseUrl: '', username: '', password: '' },
+  cloudSaver: { baseUrl: '', username: '', password: '', hasPassword: false },
   hdhive: { enabled: false, baseUrl: 'https://hdhive.com', cookie: '', hasCookie: false },
-  tmdb: { enableScraper: false, tmdbApiKey: '' },
-  openai: { 
-    enable: false, 
-    baseUrl: '', 
-    apiKey: '', 
-    model: '', 
+  tmdb: { enableScraper: false, tmdbApiKey: '', hasTmdbApiKey: false },
+  openai: {
+    enable: false,
+    baseUrl: '',
+    apiKey: '',
+    hasApiKey: false,
+    model: '',
     flowControlEnabled: false,
-    rename: { template: '{name} - {se}{ext}', movieTemplate: '{name} ({year}){ext}' } 
+    rename: { template: '{name} - {se}{ext}', movieTemplate: '{name} ({year}){ext}' }
   },
-  alist: { enable: false, baseUrl: '', apiKey: '' },
+  alist: { enable: false, baseUrl: '', apiKey: '', hasApiKey: false },
   organizer: {
     categories: {
       tv: '电视剧',
@@ -181,19 +188,38 @@ const MediaTab: React.FC = () => {
           emby: {
             ...initialSettings.emby,
             ...fetched.emby,
+            apiKey: '',
+            hasApiKey: !!fetched.emby?.hasApiKey,
             webhookSecret: '',
             proxy: { ...initialSettings.emby.proxy, ...fetched.emby?.proxy },
             prewarm: { ...initialSettings.emby.prewarm, ...fetched.emby?.prewarm }
           },
-          cloudSaver: { ...initialSettings.cloudSaver, ...fetched.cloudSaver },
+          cloudSaver: {
+            ...initialSettings.cloudSaver,
+            ...fetched.cloudSaver,
+            password: '',
+            hasPassword: !!fetched.cloudSaver?.hasPassword,
+          },
           hdhive: { ...initialSettings.hdhive, ...fetched.hdhive, cookie: '' },
-          tmdb: { ...initialSettings.tmdb, ...fetched.tmdb },
+          tmdb: {
+            ...initialSettings.tmdb,
+            ...fetched.tmdb,
+            tmdbApiKey: '',
+            hasTmdbApiKey: !!(fetched.tmdb?.hasTmdbApiKey || fetched.tmdb?.hasApiKey),
+          },
           openai: {
             ...initialSettings.openai,
             ...fetched.openai,
+            apiKey: '',
+            hasApiKey: !!fetched.openai?.hasApiKey,
             rename: { ...initialSettings.openai.rename, ...fetched.openai?.rename }
           },
-          alist: { ...initialSettings.alist, ...fetched.alist },
+          alist: {
+            ...initialSettings.alist,
+            ...fetched.alist,
+            apiKey: '',
+            hasApiKey: !!fetched.alist?.hasApiKey,
+          },
           organizer: {
             ...initialSettings.organizer,
             ...fetched.organizer,
@@ -377,11 +403,11 @@ const MediaTab: React.FC = () => {
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium text-slate-700">API Key</label>
-              <input 
-                type="password" 
+              <input
+                type="password"
                 value={settings.openai.apiKey}
                 onChange={e => updateSetting('openai.apiKey', e.target.value)}
-                placeholder="sk-..."
+                placeholder={settings.openai.hasApiKey ? '已保存 API Key；留空不覆盖' : 'sk-...'}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -571,6 +597,7 @@ const MediaTab: React.FC = () => {
                 type="password"
                 value={settings.emby.apiKey}
                 onChange={e => updateSetting('emby.apiKey', e.target.value)}
+                placeholder={settings.emby.hasApiKey ? '已保存 API Key；留空不覆盖' : 'Emby API Key'}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -703,6 +730,7 @@ const MediaTab: React.FC = () => {
                 type="password"
                 value={settings.cloudSaver.password}
                 onChange={e => updateSetting('cloudSaver.password', e.target.value)}
+                placeholder={settings.cloudSaver.hasPassword ? '已保存密码；留空不覆盖' : 'CloudSaver 密码'}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -773,10 +801,11 @@ const MediaTab: React.FC = () => {
             </div>
             <div className="space-y-1">
               <label className="text-xs font-medium text-slate-500 block">Token</label>
-              <input 
-                type="password" 
+              <input
+                type="password"
                 value={settings.alist.apiKey}
                 onChange={e => updateSetting('alist.apiKey', e.target.value)}
+                placeholder={settings.alist.hasApiKey ? '已保存 Token；留空不覆盖' : 'Alist Token'}
                 className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -793,10 +822,11 @@ const MediaTab: React.FC = () => {
           <div className={`bg-white rounded-3xl border border-slate-200/60 p-6 space-y-4 shadow-sm transition-opacity ${!settings.tmdb.enableScraper && 'opacity-60 pointer-events-none'}`}>
             <div className="space-y-1">
               <label className="text-xs font-medium text-slate-500 block">TMDB API Key</label>
-              <input 
-                type="password" 
+              <input
+                type="password"
                 value={settings.tmdb.tmdbApiKey}
                 onChange={e => updateSetting('tmdb.tmdbApiKey', e.target.value)}
+                placeholder={settings.tmdb.hasTmdbApiKey ? '已保存 API Key；留空不覆盖' : 'TMDB API Key'}
                 className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>

--- a/frontend/src/components/tabs/PtTab.tsx
+++ b/frontend/src/components/tabs/PtTab.tsx
@@ -88,6 +88,7 @@ interface DownloaderSettings {
   baseUrl: string;
   username: string;
   password: string;
+  hasPassword?: boolean;
   categoryPrefix: string;
   tagPrefix: string;
   insecureSkipTlsVerify: boolean;
@@ -342,7 +343,8 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
           type: pt.downloader?.type || 'qbittorrent',
           baseUrl: pt.downloader?.baseUrl || '',
           username: pt.downloader?.username || '',
-          password: pt.downloader?.password || '',
+          password: '',
+          hasPassword: !!pt.downloader?.hasPassword,
           categoryPrefix: pt.downloader?.categoryPrefix || 'pt-sub-',
           tagPrefix: pt.downloader?.tagPrefix || 'pt-rel-',
           insecureSkipTlsVerify: !!pt.downloader?.insecureSkipTlsVerify
@@ -1342,8 +1344,13 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                 </div>
                 <div className="space-y-2">
                   <label className="text-xs text-slate-500">密码</label>
-                  <input type="password" value={settings.downloader.password} onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, password: e.target.value } })}
-                    className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
+                  <input
+                    type="password"
+                    value={settings.downloader.password}
+                    onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, password: e.target.value } })}
+                    placeholder={settings.downloader.hasPassword ? '已保存密码；留空不覆盖' : 'qBittorrent 密码'}
+                    className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none"
+                  />
                 </div>
                 <div className="space-y-2">
                   <label className="text-xs text-slate-500">分类前缀</label>

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -61,6 +61,7 @@ interface SettingsData {
   wecom: {
     enable: boolean;
     webhook: string;
+    hasWebhook?: boolean;
   };
   telegram: {
     enable: boolean;
@@ -73,6 +74,7 @@ interface SettingsData {
     bot: {
       enable: boolean;
       botToken: string;
+      hasBotToken?: boolean;
       chatId: string;
       allowedChatIds: string[];
       adminChatIds: string[];
@@ -81,12 +83,14 @@ interface SettingsData {
   wxpusher: {
     enable: boolean;
     spt: string;
+    hasSpt?: boolean;
   };
   proxy: {
     host: string;
     port: number;
     username: string;
     password: string;
+    hasPassword?: boolean;
     services: {
       telegram: boolean;
       tmdb: boolean;
@@ -100,16 +104,19 @@ interface SettingsData {
     enable: boolean;
     serverUrl: string;
     key: string;
+    hasKey?: boolean;
   };
   system: {
     username: string;
     password: string;
     baseUrl: string;
     apiKey: string;
+    hasApiKey?: boolean;
   };
   pushplus: {
     enable: boolean;
     token: string;
+    hasToken?: boolean;
     topic: string;
     channel: string;
     webhook: string;
@@ -307,14 +314,6 @@ const SettingsTab: React.FC = () => {
               ...(loaded.task?.autoCreate || {})
             }
           },
-          proxy: {
-            ...initialSettings.proxy,
-            ...(loaded.proxy || {}),
-            services: {
-              ...initialSettings.proxy.services,
-              ...(loaded.proxy?.services || {})
-            }
-          },
           hdhive: {
             ...initialSettings.hdhive,
             ...(loaded.hdhive || {}),
@@ -334,34 +333,60 @@ const SettingsTab: React.FC = () => {
           telegram: {
             enable: loaded.telegram?.enable ?? loaded.telegram?.bot?.enable ?? false,
             proxyDomain: loaded.telegram?.proxyDomain || '',
-            botToken: loaded.telegram?.botToken || loaded.telegram?.bot?.botToken || '',
+            botToken: '',
             chatId: loaded.telegram?.chatId || loaded.telegram?.bot?.chatId || '',
             notifyOnSuccess: loaded.telegram?.notifyOnSuccess ?? true,
             notifyOnFailure: loaded.telegram?.notifyOnFailure ?? true,
             notifyOnScrape: loaded.telegram?.notifyOnScrape ?? false,
             bot: {
               enable: loaded.telegram?.bot?.enable ?? loaded.telegram?.enable ?? false,
-              botToken: loaded.telegram?.bot?.botToken || loaded.telegram?.botToken || '',
+              botToken: '',
+              hasBotToken: !!(loaded.telegram?.bot?.hasBotToken || loaded.telegram?.hasBotToken),
               chatId: loaded.telegram?.bot?.chatId || loaded.telegram?.chatId || '',
               allowedChatIds: loaded.telegram?.bot?.allowedChatIds || [],
               adminChatIds: loaded.telegram?.bot?.adminChatIds || [],
             }
           },
+          system: {
+            ...initialSettings.system,
+            ...(loaded.system || {}),
+            password: '',
+            apiKey: '',
+            hasApiKey: !!loaded.system?.hasApiKey,
+          },
           wecom: {
             ...initialSettings.wecom,
             ...(loaded.wecom || {}),
+            webhook: '',
+            hasWebhook: !!loaded.wecom?.hasWebhook,
           },
           bark: {
             ...initialSettings.bark,
             ...(loaded.bark || {}),
+            key: '',
+            hasKey: !!loaded.bark?.hasKey,
           },
           wxpusher: {
             ...initialSettings.wxpusher,
             ...(loaded.wxpusher || {}),
+            spt: '',
+            hasSpt: !!loaded.wxpusher?.hasSpt,
           },
           pushplus: {
             ...initialSettings.pushplus,
             ...(loaded.pushplus || {}),
+            token: '',
+            hasToken: !!loaded.pushplus?.hasToken,
+          },
+          proxy: {
+            ...initialSettings.proxy,
+            ...(loaded.proxy || {}),
+            password: '',
+            hasPassword: !!loaded.proxy?.hasPassword,
+            services: {
+              ...initialSettings.proxy.services,
+              ...(loaded.proxy?.services || {})
+            }
           },
           customPush: Array.isArray(loaded.customPush) ? loaded.customPush : initialSettings.customPush,
         };
@@ -602,11 +627,11 @@ const SettingsTab: React.FC = () => {
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">系统 API Key</label>
             <div className="flex gap-3">
-              <input 
-                type="text" 
+              <input
+                type="password"
                 value={settings.system.apiKey}
                 onChange={(e) => updateSettings('system.apiKey', e.target.value)}
-                placeholder="系统 API Key" 
+                placeholder={settings.system.hasApiKey ? '已保存 API Key；留空不覆盖' : '系统 API Key'}
                 className="flex-1 px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
               <button 
@@ -900,7 +925,7 @@ const SettingsTab: React.FC = () => {
                   updateSettings('telegram.botToken', e.target.value);
                 }}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
-                placeholder="123456789:ABCDefgh..."
+                placeholder={settings.telegram.bot.hasBotToken ? '已保存 Bot Token；留空不覆盖' : '123456789:ABCDefgh...'}
               />
             </div>
             <div className="space-y-2">
@@ -1024,11 +1049,11 @@ const SettingsTab: React.FC = () => {
               <div className="px-4 animate-in slide-in-from-top-2 duration-200">
                 <label className="text-xs font-medium text-slate-500 mb-1 block">Webhook URL</label>
                 <input
-                  type="text"
+                  type="password"
                   value={settings.wecom.webhook}
                   onChange={(e) => updateSettings('wecom.webhook', e.target.value)}
                   className="w-full px-4 py-2 bg-white border border-slate-200 rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
-                  placeholder="https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=..."
+                  placeholder={settings.wecom.hasWebhook ? '已保存 Webhook；留空不覆盖' : 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=...'}
                 />
               </div>
             )}
@@ -1063,11 +1088,11 @@ const SettingsTab: React.FC = () => {
                 <div>
                   <label className="text-xs font-medium text-slate-500 mb-1 block">Device Key</label>
                   <input
-                    type="text"
+                    type="password"
                     value={settings.bark.key}
                     onChange={(e) => updateSettings('bark.key', e.target.value)}
                     className="w-full px-4 py-2 bg-white border border-slate-200 rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
-                    placeholder="Bark 设备 Key"
+                    placeholder={settings.bark.hasKey ? '已保存设备 Key；留空不覆盖' : 'Bark 设备 Key'}
                   />
                 </div>
               </div>
@@ -1092,11 +1117,11 @@ const SettingsTab: React.FC = () => {
               <div className="px-4 animate-in slide-in-from-top-2 duration-200">
                 <label className="text-xs font-medium text-slate-500 mb-1 block">SPT</label>
                 <input
-                  type="text"
+                  type="password"
                   value={settings.wxpusher.spt}
                   onChange={(e) => updateSettings('wxpusher.spt', e.target.value)}
                   className="w-full px-4 py-2 bg-white border border-slate-200 rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
-                  placeholder="WxPusher 简单推送 SPT"
+                  placeholder={settings.wxpusher.hasSpt ? '已保存 SPT；留空不覆盖' : 'WxPusher 简单推送 SPT'}
                 />
               </div>
             )}
@@ -1121,11 +1146,11 @@ const SettingsTab: React.FC = () => {
                 <div className="md:col-span-2">
                   <label className="text-xs font-medium text-slate-500 mb-1 block">Token</label>
                   <input
-                    type="text"
+                    type="password"
                     value={settings.pushplus.token}
                     onChange={(e) => updateSettings('pushplus.token', e.target.value)}
                     className="w-full px-4 py-2 bg-white border border-slate-200 rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
-                    placeholder="PushPlus token"
+                    placeholder={settings.pushplus.hasToken ? '已保存 Token；留空不覆盖' : 'PushPlus token'}
                   />
                 </div>
                 <div>
@@ -1211,10 +1236,11 @@ const SettingsTab: React.FC = () => {
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium text-slate-700">代理密码</label>
-              <input 
-                type="password" 
+              <input
+                type="password"
                 value={settings.proxy.password}
                 onChange={(e) => updateSettings('proxy.password', e.target.value)}
+                placeholder={settings.proxy.hasPassword ? '已保存密码；留空不覆盖' : '代理密码'}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -16,6 +16,34 @@ const getEncryptionKey = (): Buffer => {
     return Buffer.from(configKey, 'hex');
 };
 
+// password / cookies 共用：读时解密，写时加密；已是 iv:hex 则跳过防双重加密
+const credentialTransformer = {
+    from: (value: string | null) => {
+        if (!value) return value;
+        if (!PasswordCrypto.isEncrypted(value)) {
+            return value;
+        }
+        try {
+            const key = getEncryptionKey();
+            return PasswordCrypto.decrypt(value, key);
+        } catch {
+            return value;
+        }
+    },
+    to: (value: string | null) => {
+        if (!value) return value;
+        if (PasswordCrypto.isEncrypted(value)) {
+            return value;
+        }
+        try {
+            const key = getEncryptionKey();
+            return PasswordCrypto.encrypt(value, key);
+        } catch {
+            return value;
+        }
+    }
+};
+
 @Entity()
 export class Account {
     @PrimaryGeneratedColumn()
@@ -26,32 +54,14 @@ export class Account {
 
     @Column('text', {
         nullable: true,
-        transformer: {
-            from: (value: string | null) => {
-                if (!value) return value;
-                // 自动解密存储的密码
-                try {
-                    const key = getEncryptionKey();
-                    return PasswordCrypto.decrypt(value, key);
-                } catch {
-                    return value;
-                }
-            },
-            to: (value: string | null) => {
-                if (!value) return value;
-                // 自动加密明文密码
-                try {
-                    const key = getEncryptionKey();
-                    return PasswordCrypto.encrypt(value, key);
-                } catch {
-                    return value;
-                }
-            }
-        }
+        transformer: credentialTransformer
     })
     password!: string;
 
-    @Column('text', { nullable: true})
+    @Column('text', {
+        nullable: true,
+        transformer: credentialTransformer
+    })
     cookies!: string;
 
     @Column('boolean', { default: true })

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const { Cloud189Service } = require('./services/cloud189');
 const { MessageUtil } = require('./services/message');
 const { CacheManager } = require('./services/CacheManager')
 const ConfigService = require('./services/ConfigService');
+const PasswordCrypto = require('./utils/passwordCrypto');
 const packageJson = require('../package.json');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
@@ -300,76 +301,133 @@ const prepareSettingsForSave = async (settings) => {
     return settings;
 };
 
+const getByPath = (obj, path) => {
+    if (!obj || !path) return undefined;
+    return String(path).split('.').reduce((cur, key) => (cur == null ? undefined : cur[key]), obj);
+};
+
+const setByPath = (obj, path, value) => {
+    const keys = String(path).split('.');
+    let cur = obj;
+    for (let i = 0; i < keys.length - 1; i++) {
+        const key = keys[i];
+        if (cur[key] == null || typeof cur[key] !== 'object') {
+            cur[key] = {};
+        }
+        cur = cur[key];
+    }
+    cur[keys[keys.length - 1]] = value;
+};
+
+// value 清空 + 可选 has 标记；omit 表示前端根本不需要该字段
+const SENSITIVE_SETTING_FIELDS = [
+    { path: 'system.password', clear: true },
+    { path: 'system.apiKey', has: 'system.hasApiKey' },
+    { path: 'system.sessionSecret', omit: true },
+    { path: 'system.streamProxySecret', omit: true },
+    { path: 'system.passwordEncryptionKey', omit: true },
+    { path: 'telegram.bot.botToken', has: 'telegram.bot.hasBotToken' },
+    { path: 'telegram.botToken', has: 'telegram.hasBotToken' },
+    { path: 'proxy.password', has: 'proxy.hasPassword' },
+    { path: 'bark.key', has: 'bark.hasKey' },
+    { path: 'pushplus.token', has: 'pushplus.hasToken' },
+    { path: 'wecom.webhook', has: 'wecom.hasWebhook' },
+    { path: 'wxpusher.spt', has: 'wxpusher.hasSpt' },
+    { path: 'pt.downloader.password', has: 'pt.downloader.hasPassword' },
+    { path: 'openai.apiKey', has: 'openai.hasApiKey' },
+    { path: 'emby.apiKey', has: 'emby.hasApiKey' },
+    { path: 'emby.webhookSecret', has: 'emby.hasWebhookSecret' },
+    { path: 'cloudSaver.password', has: 'cloudSaver.hasPassword' },
+    { path: 'alist.apiKey', has: 'alist.hasApiKey' },
+    { path: 'tmdb.apiKey', has: 'tmdb.hasApiKey' },
+    { path: 'tmdb.tmdbApiKey', has: 'tmdb.hasTmdbApiKey' },
+    { path: 'hdhive.cookie', has: 'hdhive.hasCookie' },
+    { path: 'hdhive.password', has: 'hdhive.hasPassword' },
+    { path: 'hdhive.apiKey', has: 'hdhive.hasApiKey' },
+    { path: 'hdhive.accessToken', has: 'hdhive.hasAccessToken' },
+    { path: 'hdhive.refreshToken', has: 'hdhive.hasRefreshToken' },
+    { path: 'hdhive.browserBridge.token', has: 'hdhive.browserBridge.hasToken' },
+];
+
 const redactSettingsForClient = (settings = {}) => {
     const redacted = JSON.parse(JSON.stringify(settings || {}));
-    if (redacted.system?.password) {
-        redacted.system.password = '';
-    }
-    if (redacted.hdhive?.cookie) {
-        redacted.hdhive.cookie = '';
-        redacted.hdhive.hasCookie = true;
-    } else if (redacted.hdhive) {
-        redacted.hdhive.hasCookie = false;
-    }
-    if (redacted.hdhive?.password) {
-        redacted.hdhive.password = '';
-        redacted.hdhive.hasPassword = true;
-    } else if (redacted.hdhive) {
-        redacted.hdhive.hasPassword = false;
-    }
-    if (redacted.hdhive?.apiKey) {
-        redacted.hdhive.apiKey = '';
-        redacted.hdhive.hasApiKey = true;
-    } else if (redacted.hdhive) {
-        redacted.hdhive.hasApiKey = false;
-    }
-    if (redacted.hdhive?.browserBridge?.token) {
-        redacted.hdhive.browserBridge.token = '';
-        redacted.hdhive.browserBridge.hasToken = true;
-    } else if (redacted.hdhive?.browserBridge) {
-        redacted.hdhive.browserBridge.hasToken = false;
-    }
-    if (redacted.emby?.webhookSecret) {
-        redacted.emby.webhookSecret = '';
-        redacted.emby.hasWebhookSecret = true;
-    } else if (redacted.emby) {
-        redacted.emby.hasWebhookSecret = false;
+    for (const field of SENSITIVE_SETTING_FIELDS) {
+        const value = getByPath(redacted, field.path);
+        const hasValue = value != null && String(value).trim() !== '';
+        if (field.omit) {
+            const keys = field.path.split('.');
+            let cur = redacted;
+            for (let i = 0; i < keys.length - 1; i++) {
+                if (!cur?.[keys[i]]) {
+                    cur = null;
+                    break;
+                }
+                cur = cur[keys[i]];
+            }
+            if (cur && Object.prototype.hasOwnProperty.call(cur, keys[keys.length - 1])) {
+                delete cur[keys[keys.length - 1]];
+            }
+            continue;
+        }
+        // 仅当父对象存在时写 has 标记，避免凭空造出配置节点
+        const parentPath = field.path.includes('.')
+            ? field.path.slice(0, field.path.lastIndexOf('.'))
+            : null;
+        const parentExists = !parentPath || getByPath(redacted, parentPath) != null;
+        if (parentExists && field.has) {
+            setByPath(redacted, field.has, hasValue);
+        }
+        if (parentExists) {
+            setByPath(redacted, field.path, '');
+        }
     }
     return redacted;
 };
 
-const preserveHdhiveSensitiveOnEmptyInput = (settings = {}) => {
-    if (settings.hdhive) {
-        const currentHdhive = ConfigService.getConfigValue('hdhive', {}) || {};
-        const nextCookie = String(settings.hdhive.cookie || '').trim();
-        const nextApiKey = String(settings.hdhive.apiKey || '').trim();
-        const nextPassword = String(settings.hdhive.password || '').trim();
-        const nextBridgeToken = String(settings.hdhive.browserBridge?.token || '').trim();
-        settings.hdhive = {
-            ...currentHdhive,
-            ...settings.hdhive,
-            cookie: nextCookie || ConfigService.getConfigValue('hdhive.cookie', ''),
-            apiKey: nextApiKey || ConfigService.getConfigValue('hdhive.apiKey', ''),
-            password: nextPassword || ConfigService.getConfigValue('hdhive.password', ''),
-            browserBridge: {
-                ...(currentHdhive.browserBridge || {}),
-                ...(settings.hdhive.browserBridge || {}),
-                token: nextBridgeToken || ConfigService.getConfigValue('hdhive.browserBridge.token', '')
-            }
-        };
+// 请求体敏感字段为空时保留服务端已有值，避免前端脱敏后回写把密钥抹掉
+// 注意 ConfigService.setConfig 是浅合并：settings.system 整对象替换时，
+// 必须把 sessionSecret 等 omit 字段写回请求体，否则会被冲掉
+const preserveSensitiveOnEmptyInput = (settings = {}) => {
+    if (!settings || typeof settings !== 'object') {
+        return settings;
     }
-    return settings;
-};
-
-const preserveEmbySensitiveOnEmptyInput = (settings = {}) => {
-    if (settings.emby) {
-        const currentEmby = ConfigService.getConfigValue('emby', {}) || {};
-        const nextWebhookSecret = String(settings.emby.webhookSecret || '').trim();
-        settings.emby = {
-            ...currentEmby,
-            ...settings.emby,
-            webhookSecret: nextWebhookSecret || ConfigService.getConfigValue('emby.webhookSecret', '')
-        };
+    for (const field of SENSITIVE_SETTING_FIELDS) {
+        const parentPath = field.path.includes('.')
+            ? field.path.slice(0, field.path.lastIndexOf('.'))
+            : null;
+        // 仅当请求体带了该父节点时才处理，避免无端展开
+        if (parentPath && getByPath(settings, parentPath) == null) {
+            continue;
+        }
+        if (field.omit) {
+            // sessionSecret / streamProxySecret / passwordEncryptionKey 仅服务端持有
+            const current = ConfigService.getConfigValue(field.path, '');
+            if (current != null && current !== '') {
+                setByPath(settings, field.path, current);
+            } else {
+                const keys = field.path.split('.');
+                let cur = settings;
+                for (let i = 0; i < keys.length - 1; i++) {
+                    if (!cur?.[keys[i]]) {
+                        cur = null;
+                        break;
+                    }
+                    cur = cur[keys[i]];
+                }
+                if (cur && Object.prototype.hasOwnProperty.call(cur, keys[keys.length - 1])) {
+                    delete cur[keys[keys.length - 1]];
+                }
+            }
+            continue;
+        }
+        const incoming = getByPath(settings, field.path);
+        if (incoming != null && String(incoming).trim() !== '') {
+            continue;
+        }
+        const current = ConfigService.getConfigValue(field.path, '');
+        if (current != null && current !== '') {
+            setByPath(settings, field.path, current);
+        }
     }
     return settings;
 };
@@ -888,13 +946,32 @@ AppDataSource.initialize().then(async () => {
         if (process.getuid && process.getuid() === 0) {
             await fs.chown(strmBaseDir, parseInt(process.env.PUID || 0), parseInt(process.env.PGID || 0));
         }
-        await fs.chmod(strmBaseDir, 0o777);
+        await fs.chmod(strmBaseDir, 0o755);
         console.log('STRM目录权限初始化完成');
     } catch (error) {
         console.error('STRM目录权限初始化失败:', error);
     }
 
     const accountRepo = AppDataSource.getRepository(Account);
+    // 仅将库中仍为明文的 password/cookies 经 transformer 加密写回
+    try {
+        const rawRows = await AppDataSource.query('SELECT id, password, cookies FROM account');
+        let upgraded = 0;
+        for (const row of rawRows || []) {
+            const needsPassword = row.password && !PasswordCrypto.isEncrypted(row.password);
+            const needsCookies = row.cookies && !PasswordCrypto.isEncrypted(row.cookies);
+            if (!needsPassword && !needsCookies) continue;
+            const account = await accountRepo.findOneBy({ id: row.id });
+            if (!account) continue;
+            await accountRepo.save(account);
+            upgraded++;
+        }
+        if (upgraded > 0) {
+            console.log(`账号凭据加密规范化完成: ${upgraded} 条`);
+        }
+    } catch (error) {
+        console.warn('账号凭据加密规范化跳过:', error.message);
+    }
     const taskRepo = AppDataSource.getRepository(Task);
     const commonFolderRepo = AppDataSource.getRepository(CommonFolder);
     const subscriptionRepo = AppDataSource.getRepository(Subscription);
@@ -971,7 +1048,7 @@ AppDataSource.initialize().then(async () => {
         const accounts = await accountRepo.find();
         // 获取容量
         for (const account of accounts) {
-            
+
             account.capacity = {
                 cloudCapacityInfo: {usedSize:0,totalSize:0},
                 familyCapacityInfo: {usedSize:0,totalSize:0}
@@ -991,6 +1068,11 @@ AppDataSource.initialize().then(async () => {
             account.driveLabel = account.accountType === 'family' ? '家庭云' : '个人云';
             // username脱敏
             account.username = maskUsername(account.username);
+            // 凭据不得下发前端
+            account.hasPassword = !!account.password;
+            account.hasCookies = !!account.cookies;
+            delete account.password;
+            delete account.cookies;
         }
         res.json({ success: true, data: accounts });
     });
@@ -1142,16 +1224,52 @@ AppDataSource.initialize().then(async () => {
 
     app.post('/api/accounts', async (req, res) => {
         try {
-            const account = accountRepo.create(req.body);
+            const body = req.body || {};
+            const accountId = body.id != null && body.id !== '' ? Number(body.id) : null;
+            const isUpdate = Number.isInteger(accountId) && accountId > 0;
+            let existing = null;
+            if (isUpdate) {
+                existing = await accountRepo.findOneBy({ id: accountId });
+                if (!existing) {
+                    return res.json({ success: false, error: '账号不存在' });
+                }
+            }
+
+            const incomingPassword = body.password != null ? String(body.password) : '';
+            const incomingCookies = body.cookies != null ? String(body.cookies) : '';
+            const password = incomingPassword.trim()
+                ? incomingPassword
+                : (isUpdate ? (existing.password || '') : '');
+            const cookies = incomingCookies.trim()
+                ? incomingCookies
+                : (isUpdate ? (existing.cookies || '') : '');
+
+            if (!isUpdate && !password && !cookies) {
+                return res.json({ success: false, error: '密码和Cookie不能同时为空' });
+            }
+
+            const account = isUpdate
+                ? accountRepo.merge(existing, {
+                    ...body,
+                    id: existing.id,
+                    password,
+                    cookies,
+                })
+                : accountRepo.create({
+                    ...body,
+                    password,
+                    cookies,
+                });
+
             account.accountType = account.accountType || 'personal';
             account.familyId = account.accountType === 'family' ? (account.familyId || '') : null;
-            account.familyFolderId = account.accountType === 'family' ? (req.body.familyFolderId || account.familyFolderId || '') : '';
+            account.familyFolderId = account.accountType === 'family' ? (body.familyFolderId || account.familyFolderId || '') : '';
             Cloud189Service.invalidateByUsername(account.username);
             // 尝试登录, 登录成功写入store, 如果需要验证码, 则返回用户验证码图片
-            if (!account.username.startsWith('n_') && account.password) {
-                // 尝试登录
+            if (!account.username.startsWith('n_') && account.password && incomingPassword.trim()) {
+                // 仅当本次提交了新密码时尝试登录，避免「留空不改」误触发
                 const cloud189 = Cloud189Service.getInstance(account);
-                const loginResult = await cloud189.login(account.username, account.password, req.body.validateCode);
+                const loginResult = await cloud189.login(account.username, account.password, body.validateCode);
                 if (!loginResult.success) {
                     if (loginResult.code == "NEED_CAPTCHA") {
                         res.json({
@@ -2294,10 +2412,8 @@ AppDataSource.initialize().then(async () => {
     })
 
     app.post('/api/settings', async (req, res) => {
-        const settings = preserveEmbySensitiveOnEmptyInput(
-            preserveHdhiveSensitiveOnEmptyInput(
-                await prepareSettingsForSave(normalizeTelegramSettings(req.body))
-            )
+        const settings = preserveSensitiveOnEmptyInput(
+            await prepareSettingsForSave(normalizeTelegramSettings(req.body))
         );
         SchedulerService.handleScheduleTasks(settings,taskService);
         ConfigService.setConfig(settings)
@@ -2353,9 +2469,7 @@ AppDataSource.initialize().then(async () => {
     // 保存媒体配置
     app.post('/api/settings/media', async (req, res) => {
         try {
-            const settings = preserveEmbySensitiveOnEmptyInput(
-                preserveHdhiveSensitiveOnEmptyInput(req.body || {})
-            );
+            const settings = preserveSensitiveOnEmptyInput(req.body || {});
             // 如果cloudSaver的配置变更 就清空cstoken.json
             if (settings.cloudSaver?.baseUrl != ConfigService.getConfigValue('cloudSaver.baseUrl')
             || settings.cloudSaver?.username != ConfigService.getConfigValue('cloudSaver.username')

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>天翼云盘自动转存系统</title>
-    <script type="module" crossorigin src="/assets/index-DVd5igXV.js"></script>
+    <script type="module" crossorigin src="/assets/index-BOLlwlpa.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DR9wKSv0.css">
   </head>
   <body>

--- a/src/services/strm.js
+++ b/src/services/strm.js
@@ -2,7 +2,6 @@ const fs = require('fs').promises;
 const path = require('path');
 const ConfigService = require('./ConfigService');
 const { logTaskEvent } = require('../utils/logUtils');
-const CryptoUtils = require('../utils/cryptoUtils');
 const alistService = require('./alistService');
 const { MessageUtil } = require('./message');
 const { StreamProxyService } = require('./streamProxy');
@@ -124,7 +123,7 @@ class StrmService {
                     if (process.getuid && process.getuid() === 0) {
                         await fs.chown(strmPath, parseInt(this.puid), parseInt(this.pgid));
                     }
-                    await fs.chmod(strmPath, 0o777);
+                    await fs.chmod(strmPath, 0o644);
                     results.push({
                         originalFile: fileName,
                         strmFile: path.basename(strmPath),
@@ -211,7 +210,7 @@ class StrmService {
                     if (process.getuid && process.getuid() === 0) {
                         await fs.chown(currentPath, parseInt(this.puid), parseInt(this.pgid));
                     }
-                    await fs.chmod(currentPath, 0o777);
+                    await fs.chmod(currentPath, 0o755);
                 } catch (error) {
                     if (error.code !== 'EEXIST') {
                         throw new Error(`创建目录失败: ${error.message}`);
@@ -330,7 +329,7 @@ class StrmService {
                 if (process.getuid && process.getuid() === 0) {
                     await fs.chown(strmPath, parseInt(this.puid), parseInt(this.pgid));
                 }
-                await fs.chmod(strmPath, 0o777);
+                await fs.chmod(strmPath, 0o644);
                 success++;
                 logTaskEvent(`生成STRM文件成功: ${strmPath}`);
             } catch (error) {
@@ -638,7 +637,7 @@ class StrmService {
                     if (process.getuid && process.getuid() === 0) {
                         await fs.chown(strmPath, parseInt(this.puid), parseInt(this.pgid));
                     }
-                    await fs.chmod(strmPath, 0o777);
+                    await fs.chmod(strmPath, 0o644);
 
                     stats.success++;
                     logTaskEvent(`生成STRM文件成功: ${strmPath}`);
@@ -710,7 +709,7 @@ class StrmService {
                 if (process.getuid && process.getuid() === 0) {
                     await fs.chown(strmPath, parseInt(this.puid), parseInt(this.pgid));
                 }
-                await fs.chmod(strmPath, 0o777);
+                await fs.chmod(strmPath, 0o644);
                 stats.success++;
                 logTaskEvent(`生成STRM文件成功: ${strmPath}`);
             } catch (error) {

--- a/src/utils/cryptoUtils.js
+++ b/src/utils/cryptoUtils.js
@@ -1,19 +1,38 @@
 const crypto = require('crypto');
 
 class CryptoUtils {
+    static _getKey() {
+        const raw = process.env.ENCRYPTION_KEY;
+        if (!raw || !String(raw).trim()) {
+            throw new Error('ENCRYPTION_KEY is required (no default secret)');
+        }
+        // 支持 32 字节 hex，或任意字符串经 sha256 派生为 32 字节
+        const trimmed = String(raw).trim();
+        if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+            return Buffer.from(trimmed, 'hex');
+        }
+        return crypto.createHash('sha256').update(trimmed).digest();
+    }
+
     static encryptIds(taskId, fileId) {
-        const key = process.env.ENCRYPTION_KEY || 'your-encryption-key';
+        const key = CryptoUtils._getKey();
+        const iv = crypto.randomBytes(16);
         const data = `${taskId}:${fileId}`;
-        const cipher = crypto.createCipher('aes-256-cbc', key);
+        const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
         let encrypted = cipher.update(data, 'utf8', 'hex');
         encrypted += cipher.final('hex');
-        return encrypted;
+        return `${iv.toString('hex')}:${encrypted}`;
     }
 
     static decryptIds(encrypted) {
-        const key = process.env.ENCRYPTION_KEY || 'your-encryption-key';
-        const decipher = crypto.createDecipher('aes-256-cbc', key);
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+        const key = CryptoUtils._getKey();
+        const [ivHex, payload] = String(encrypted || '').split(':');
+        if (!ivHex || !payload) {
+            throw new Error('Invalid encrypted payload');
+        }
+        const iv = Buffer.from(ivHex, 'hex');
+        const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+        let decrypted = decipher.update(payload, 'hex', 'utf8');
         decrypted += decipher.final('utf8');
         const [taskId, fileId] = decrypted.split(':');
         return { taskId, fileId };


### PR DESCRIPTION
## Summary
- 统一 `/api/settings` 敏感字段脱敏（apiKey / botToken / 各密码 / token），并在保存时对空输入保留旧值，避免前端回写抹掉密钥
- `/api/accounts` 不再返回 `password`/`cookies`，改为 `hasPassword`/`hasCookies`；更新账号时空凭据保留旧值
- `Account.cookies` 与 `password` 共用 AES transformer，启动时升级库内明文；去掉 `cryptoUtils` 默认密钥与 STRM `0o777`
- 前端 Account / Settings / Media / Pt 对齐 `has*` 与「留空不覆盖」

## Test plan
- [ ] 登录后 `GET /api/settings`：无真实密钥，已配置项有 `hasXxx=true`
- [ ] 设置页 / 媒体页不改密钥直接保存：`data/config.json` 中密钥仍在
- [ ] `GET /api/accounts`：无 `password`/`cookies` 字段
- [ ] 编辑已有账号，密码/Cookie 留空保存后仍可正常转存/登录
- [ ] 新建账号仍要求密码或 Cookie 至少一个
- [ ] 新生成 STRM 文件/目录权限不是 777
- [ ] 回归：登录、任务列表、PT 设置打开/保存、影巢 hasCookie 展示正常