### PR TITLE
fix(ui): 修滚动锁、Modal portal 与层高栈

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,8 @@ import PtTab, { type PtPrefillData } from './components/tabs/PtTab';
 import PosterWallTab from './components/tabs/PosterWallTab';
 import HdhiveTab, { type HdhivePrefillData } from './components/tabs/HdhiveTab';
 import { useDialog } from './components/ui/Dialog';
+import { lockBodyScroll, unlockBodyScroll } from './lib/bodyScrollLock';
+import { pushOverlay, popOverlay, getOverlayZIndex } from './lib/overlayStack';
 
 // --- Types ---
 export type TabType = 'account' | 'fileManager' | 'task' | 'autoSeries' | 'hdhive' | 'organizer' | 'subscription' | 'strmConfig' | 'media' | 'cas' | 'pt' | 'posterWall' | 'settings';
@@ -90,6 +92,7 @@ export default function App() {
   const [username, setUsername] = useState('');
   const [ptPrefill, setPtPrefill] = useState<PtPrefillData | null>(null);
   const [hdhivePrefill, setHdhivePrefill] = useState<HdhivePrefillData | null>(null);
+  const [mobileDrawerZ, setMobileDrawerZ] = useState({ backdrop: 150, panel: 151 });
 
   const resolvedTheme = themeMode === 'system'
     ? (systemPrefersDark ? 'dark' : 'light')
@@ -129,8 +132,9 @@ export default function App() {
       }
     };
 
+    // Esc for theme menu only — drawer/modal Esc 走 overlayStack（capture）
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && isThemeMenuOpen) {
         setIsThemeMenuOpen(false);
       }
     };
@@ -142,7 +146,26 @@ export default function App() {
       document.removeEventListener('mousedown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [isThemeMenuOpen]);
+
+  // 移动端抽屉：锁滚动 + 接入 overlay 栈（Esc / 层高）
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    lockBodyScroll();
+    const id = pushOverlay({
+      kind: 'drawer',
+      onEscape: () => setIsMobileMenuOpen(false),
+    });
+    setMobileDrawerZ(getOverlayZIndex(id, 'drawer'));
+
+    return () => {
+      popOverlay(id);
+      unlockBodyScroll();
+    };
+  }, [isMobileMenuOpen]);
 
   useEffect(() => {
     if (isDarkMode) {
@@ -255,14 +278,16 @@ export default function App() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               onClick={() => setIsMobileMenuOpen(false)}
-              className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-40 md:hidden dark:bg-slate-950/70"
+              style={{ zIndex: mobileDrawerZ.backdrop }}
+              className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm md:hidden dark:bg-slate-950/70"
             />
             <motion.nav
               initial={{ x: '-100%' }}
               animate={{ x: 0 }}
               exit={{ x: '-100%' }}
               transition={{ type: 'spring', bounce: 0, duration: 0.4 }}
-              className="fixed inset-y-0 left-0 w-72 bg-[var(--bg-surface)] flex flex-col z-50 md:hidden shadow-2xl border-r border-[var(--border-color)]"
+              style={{ zIndex: mobileDrawerZ.panel }}
+              className="fixed inset-y-0 left-0 w-72 bg-[var(--bg-surface)] flex flex-col md:hidden shadow-2xl border-r border-[var(--border-color)]"
             >
               <div className="px-6 py-8 border-b border-[var(--border-color)]">
                 <h1 className="text-2xl font-medium text-[var(--text-primary)]">天翼自动转存</h1>
@@ -363,7 +388,7 @@ export default function App() {
               <motion.button
                 type="button"
                 onClick={() => setIsThemeMenuOpen((currentState) => !currentState)}
-                whileHover={{ scale: 1.05, rotate: 15 }}
+                whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
                 className="p-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 transition-all duration-200 text-[var(--text-primary)]"
                 title={currentThemeLabel}
@@ -500,7 +525,7 @@ export default function App() {
           </div>
         </div>
 
-        <FloatingActions onAction={handleFloatingAction} />
+        {!isMobileMenuOpen && <FloatingActions onAction={handleFloatingAction} />}
       </main>
 
       {/* Modals */}

--- a/frontend/src/components/FloatingActions.tsx
+++ b/frontend/src/components/FloatingActions.tsx
@@ -19,7 +19,7 @@ const FloatingActions: React.FC<FloatingActionsProps> = ({ onAction }) => {
     { id: 'createTask', icon: Plus, label: '创建任务', color: 'bg-[#0b57d0] text-white' },
     { id: 'cloudsaver', icon: Cpu, label: 'CloudSaver', color: 'bg-[#d3e3fd] text-[#0b57d0]' },
     { id: 'chat', icon: MessageSquare, label: 'AI 助手', color: 'bg-[#f3e8ff] text-[#7e22ce]' },
-    { id: 'strm', icon: Link2, label: 'STRM 生成', color: 'bg-[#c4eed0] text-[#146c2e]' },
+    { id: 'strm', icon: Link2, label: 'STRM 配置', color: 'bg-[#c4eed0] text-[#146c2e]' },
     { id: 'logs', icon: FileText, label: '实时日志', color: 'bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-100' },
   ];
 

--- a/frontend/src/components/LogConsole.tsx
+++ b/frontend/src/components/LogConsole.tsx
@@ -232,7 +232,7 @@ const LogConsole: React.FC<LogConsoleProps> = ({ isOpen, onClose }) => {
       onClose={onClose}
       title="系统实时日志"
       maxWidthClass="max-w-5xl"
-      contentClassName="px-5 md:px-8 pb-6 max-h-[70vh] overflow-y-auto custom-scrollbar"
+      contentClassName="px-5 md:px-8 pb-6 flex flex-col min-h-0 max-h-[min(70vh,640px)] overflow-hidden"
       footer={
         <div className="px-5 md:px-8 py-4 flex flex-col gap-4 border-t border-[var(--modal-border)] bg-white/70 dark:bg-slate-900/60 sm:flex-row sm:items-center sm:justify-between">
           <Checkbox
@@ -261,8 +261,8 @@ const LogConsole: React.FC<LogConsoleProps> = ({ isOpen, onClose }) => {
         </div>
       }
     >
-      <div className="space-y-4 pt-5">
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="space-y-4 pt-5 flex flex-col min-h-0 flex-1">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 shrink-0">
           <div className="rounded-2xl border border-[var(--modal-border)] bg-white px-4 py-3 dark:bg-slate-900/60">
             <div className="text-xs text-[var(--text-secondary)]">连接状态</div>
             <div className="mt-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
@@ -286,7 +286,7 @@ const LogConsole: React.FC<LogConsoleProps> = ({ isOpen, onClose }) => {
 
         <div
           ref={scrollRef}
-          className="h-[430px] overflow-y-auto rounded-2xl border border-[var(--modal-border)] bg-white p-3 custom-scrollbar dark:bg-slate-950/40"
+          className="h-[min(430px,50vh)] flex-1 min-h-[200px] overflow-y-auto rounded-2xl border border-[var(--modal-border)] bg-white p-3 custom-scrollbar dark:bg-slate-950/40"
         >
           {logs.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center text-center text-[var(--text-secondary)]">

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { X } from 'lucide-react';
 import { lockBodyScroll, unlockBodyScroll } from '../lib/bodyScrollLock';
-import { pushOverlay, popOverlay } from '../lib/overlayStack';
+import { pushOverlay, popOverlay, getOverlayZIndex } from '../lib/overlayStack';
 
 interface ModalProps {
   isOpen: boolean;
@@ -25,25 +26,41 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const [overlayId, setOverlayId] = useState<number | null>(null);
+  const [z, setZ] = useState({ backdrop: 200, panel: 201 });
 
   useEffect(() => {
     if (!isOpen) {
+      setOverlayId(null);
       return;
     }
 
     lockBodyScroll();
-    const overlayId = pushOverlay({
+    const id = pushOverlay({
       kind: 'modal',
       onEscape: () => onCloseRef.current()
     });
+    setOverlayId(id);
+    setZ(getOverlayZIndex(id, 'modal'));
 
     return () => {
-      popOverlay(overlayId);
+      popOverlay(id);
       unlockBodyScroll();
+      setOverlayId(null);
     };
   }, [isOpen]);
 
-  return (
+  // refresh z when stack depth changes after sibling opens
+  useEffect(() => {
+    if (overlayId == null) return;
+    setZ(getOverlayZIndex(overlayId, 'modal'));
+  }, [overlayId, isOpen]);
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
     <AnimatePresence>
       {isOpen && (
         <>
@@ -52,7 +69,8 @@ const Modal: React.FC<ModalProps> = ({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
-            className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-[200]"
+            style={{ zIndex: z.backdrop }}
+            className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm"
           />
           <motion.div
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
@@ -60,7 +78,8 @@ const Modal: React.FC<ModalProps> = ({
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             role="dialog"
             aria-modal="true"
-            className={`fixed left-1/2 top-1/2 flex max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col ${maxWidthClass} rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl z-[201] overflow-hidden`}
+            style={{ zIndex: z.panel }}
+            className={`fixed left-1/2 top-1/2 flex max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col ${maxWidthClass} rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl overflow-hidden`}
           >
             <div className="px-8 py-6 flex shrink-0 items-center justify-between border-b border-[var(--modal-border)]">
               <h3 className="text-2xl font-normal text-[var(--text-primary)]">{title}</h3>
@@ -101,7 +120,8 @@ const Modal: React.FC<ModalProps> = ({
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 };
 

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState, ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import { AlertTriangle, HelpCircle, Info, AlertOctagon } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Info, AlertOctagon } from 'lucide-react';
 import { lockBodyScroll, unlockBodyScroll } from '../../lib/bodyScrollLock';
-import { pushOverlay, popOverlay, updateOverlay } from '../../lib/overlayStack';
+import { pushOverlay, popOverlay, updateOverlay, getOverlayZIndex } from '../../lib/overlayStack';
 
 export type DialogTone = 'info' | 'danger' | 'warning' | 'success';
 
@@ -45,7 +45,7 @@ const toneIconMap: Record<DialogTone, typeof AlertTriangle> = {
   info: Info,
   warning: AlertTriangle,
   danger: AlertOctagon,
-  success: HelpCircle,
+  success: CheckCircle2 as typeof AlertTriangle,
 };
 
 const toneStyleMap: Record<DialogTone, { iconBg: string; iconColor: string; confirmBg: string }> = {
@@ -173,6 +173,9 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
     }
   }, [type]);
 
+  const overlayIdRef = useRef<number | null>(null);
+  const [z, setZ] = useState({ backdrop: 400, panel: 401 });
+
   useEffect(() => {
     lockBodyScroll();
     const overlayId = pushOverlay({
@@ -180,18 +183,23 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
       onEscape: handleCancel,
       onEnter: type === 'prompt' && options.multiline ? undefined : handleConfirm,
     });
+    overlayIdRef.current = overlayId;
+    setZ(getOverlayZIndex(overlayId, 'dialog'));
 
     return () => {
       popOverlay(overlayId);
       unlockBodyScroll();
+      overlayIdRef.current = null;
     };
   }, [handleCancel, handleConfirm, type, options.multiline]);
 
   useEffect(() => {
-    // keep handlers fresh for stack top without re-register churn beyond deps above
-  }, []);
-
-  void updateOverlay;
+    if (overlayIdRef.current == null) return;
+    updateOverlay(overlayIdRef.current, {
+      onEscape: handleCancel,
+      onEnter: type === 'prompt' && options.multiline ? undefined : handleConfirm,
+    });
+  }, [handleCancel, handleConfirm, type, options.multiline]);
 
   const confirmText = options.confirmText ?? (type === 'prompt' ? '确定' : type === 'alert' ? '知道了' : '确认');
   const cancelText = options.cancelText ?? '取消';
@@ -203,7 +211,8 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         onClick={handleCancel}
-        className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-[400]"
+        style={{ zIndex: z.backdrop }}
+        className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm"
       />
       <motion.div
         initial={{ opacity: 0, scale: 0.95, y: 20 }}
@@ -212,7 +221,8 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
         transition={{ type: 'spring', stiffness: 380, damping: 30 }}
         role="dialog"
         aria-modal="true"
-        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] max-w-md rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl z-[401] overflow-hidden"
+        style={{ zIndex: z.panel }}
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] max-w-md rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl overflow-hidden"
       >
         <div className="px-6 pt-6 pb-2 flex items-start gap-4">
           {options.icon !== null && (

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -118,7 +118,7 @@ export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       {children}
       {typeof document !== 'undefined' &&
         createPortal(
-          <div className="fixed inset-x-0 bottom-6 z-[300] flex flex-col items-center gap-2 pointer-events-none px-4">
+          <div className="fixed inset-x-0 bottom-28 z-[500] flex flex-col items-center gap-2 pointer-events-none px-4">
             <AnimatePresence initial={false}>
               {toasts.map((toast) => {
                 const Icon = iconMap[toast.variant];

--- a/frontend/src/lib/bodyScrollLock.ts
+++ b/frontend/src/lib/bodyScrollLock.ts
@@ -1,5 +1,14 @@
 let lockCount = 0;
-let previousOverflow = '';
+let previousBodyOverflow = '';
+let previousScrollableOverflow = '';
+let lockedScrollable: HTMLElement | null = null;
+
+function getMainScrollable(): HTMLElement | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  return document.querySelector('.content-scrollable') as HTMLElement | null;
+}
 
 export function lockBodyScroll() {
   if (typeof document === 'undefined') {
@@ -7,8 +16,18 @@ export function lockBodyScroll() {
   }
 
   if (lockCount === 0) {
-    previousOverflow = document.body.style.overflow;
+    previousBodyOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+
+    const scrollable = getMainScrollable();
+    if (scrollable) {
+      lockedScrollable = scrollable;
+      previousScrollableOverflow = scrollable.style.overflow;
+      scrollable.style.overflow = 'hidden';
+    } else {
+      lockedScrollable = null;
+      previousScrollableOverflow = '';
+    }
   }
 
   lockCount += 1;
@@ -26,7 +45,13 @@ export function unlockBodyScroll() {
   lockCount -= 1;
 
   if (lockCount === 0) {
-    document.body.style.overflow = previousOverflow;
-    previousOverflow = '';
+    document.body.style.overflow = previousBodyOverflow;
+    previousBodyOverflow = '';
+
+    if (lockedScrollable) {
+      lockedScrollable.style.overflow = previousScrollableOverflow;
+      lockedScrollable = null;
+      previousScrollableOverflow = '';
+    }
   }
 }

--- a/frontend/src/lib/overlayStack.ts
+++ b/frontend/src/lib/overlayStack.ts
@@ -1,4 +1,4 @@
-type OverlayKind = 'modal' | 'dialog';
+type OverlayKind = 'modal' | 'dialog' | 'drawer';
 
 interface OverlayEntry {
   id: number;
@@ -11,6 +11,13 @@ let nextId = 1;
 const stack: OverlayEntry[] = [];
 let listening = false;
 
+/** Base z-index for stack layers (backdrop = base + index*10, panel = +1) */
+const Z_BASE: Record<OverlayKind, number> = {
+  drawer: 150,
+  modal: 200,
+  dialog: 400,
+};
+
 const handleKeyDown = (event: KeyboardEvent) => {
   const top = stack[stack.length - 1];
   if (!top) {
@@ -19,6 +26,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
 
   if (event.key === 'Escape') {
     event.preventDefault();
+    event.stopPropagation();
     top.onEscape();
     return;
   }
@@ -38,7 +46,8 @@ const ensureListener = () => {
   if (listening || typeof window === 'undefined') {
     return;
   }
-  window.addEventListener('keydown', handleKeyDown);
+  // capture phase so we win over App-level document listeners
+  window.addEventListener('keydown', handleKeyDown, true);
   listening = true;
 };
 
@@ -46,7 +55,7 @@ const maybeRemoveListener = () => {
   if (!listening || stack.length > 0 || typeof window === 'undefined') {
     return;
   }
-  window.removeEventListener('keydown', handleKeyDown);
+  window.removeEventListener('keydown', handleKeyDown, true);
   listening = false;
 };
 
@@ -79,4 +88,20 @@ export function updateOverlay(
   if (patch.onEnter !== undefined) {
     target.onEnter = patch.onEnter;
   }
+}
+
+/** Stack depth of this overlay (0-based among same/all); used for z-index stacking */
+export function getOverlayDepth(id: number): number {
+  return stack.findIndex((item) => item.id === id);
+}
+
+export function getOverlayZIndex(id: number, kind: OverlayKind = 'modal'): { backdrop: number; panel: number } {
+  const depth = Math.max(0, getOverlayDepth(id));
+  // each nested layer +10 so later modals sit above earlier ones
+  const base = Z_BASE[kind] + depth * 10;
+  return { backdrop: base, panel: base + 1 };
+}
+
+export function getStackSize(): number {
+  return stack.length;
 }


### PR DESCRIPTION
## Summary
修壳层交互的硬伤：弹窗开着背景仍能滚、嵌套目录选择器被父 Modal 裁切、手机抽屉被 FAB 压住。

## Changes
- `bodyScrollLock` 同步锁定 `.content-scrollable`
- `Modal` portal 到 `document.body`，按 overlay 层深算 z-index
- 移动抽屉接入 lock + Esc 栈，打开时隐藏 FAB
- Toast 提到 z-500 上移避开 FAB；Dialog success 图标修正
- LogConsole 去掉双滚动；FAB「STRM 生成」改「STRM 配置」

## Test plan
- [ ] 打开创建任务/日志/AI，背后任务列表不可滚
- [ ] 创建任务里开「选择目录」，遮罩铺满视口、Esc 先关目录再关任务
- [ ] 手机开汉堡菜单，FAB 消失且 Esc 可关菜单
- [ ] Toast 在 Dialog 打开时仍可见

依赖：无  
后续：#PR2 危险确认、#PR3 表单正确性（叠在本分支上）