### PR TITLE
fix(ui): 表单/选择正确性与创建任务体验

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,8 @@ import PtTab, { type PtPrefillData } from './components/tabs/PtTab';
 import PosterWallTab from './components/tabs/PosterWallTab';
 import HdhiveTab, { type HdhivePrefillData } from './components/tabs/HdhiveTab';
 import { useDialog } from './components/ui/Dialog';
+import { lockBodyScroll, unlockBodyScroll } from './lib/bodyScrollLock';
+import { pushOverlay, popOverlay, getOverlayZIndex } from './lib/overlayStack';
 
 // --- Types ---
 export type TabType = 'account' | 'fileManager' | 'task' | 'autoSeries' | 'hdhive' | 'organizer' | 'subscription' | 'strmConfig' | 'media' | 'cas' | 'pt' | 'posterWall' | 'settings';
@@ -90,6 +92,7 @@ export default function App() {
   const [username, setUsername] = useState('');
   const [ptPrefill, setPtPrefill] = useState<PtPrefillData | null>(null);
   const [hdhivePrefill, setHdhivePrefill] = useState<HdhivePrefillData | null>(null);
+  const [mobileDrawerZ, setMobileDrawerZ] = useState({ backdrop: 150, panel: 151 });
 
   const resolvedTheme = themeMode === 'system'
     ? (systemPrefersDark ? 'dark' : 'light')
@@ -129,8 +132,9 @@ export default function App() {
       }
     };
 
+    // Esc for theme menu only — drawer/modal Esc 走 overlayStack（capture）
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && isThemeMenuOpen) {
         setIsThemeMenuOpen(false);
       }
     };
@@ -142,7 +146,26 @@ export default function App() {
       document.removeEventListener('mousedown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [isThemeMenuOpen]);
+
+  // 移动端抽屉：锁滚动 + 接入 overlay 栈（Esc / 层高）
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    lockBodyScroll();
+    const id = pushOverlay({
+      kind: 'drawer',
+      onEscape: () => setIsMobileMenuOpen(false),
+    });
+    setMobileDrawerZ(getOverlayZIndex(id, 'drawer'));
+
+    return () => {
+      popOverlay(id);
+      unlockBodyScroll();
+    };
+  }, [isMobileMenuOpen]);
 
   useEffect(() => {
     if (isDarkMode) {
@@ -255,14 +278,16 @@ export default function App() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               onClick={() => setIsMobileMenuOpen(false)}
-              className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-40 md:hidden dark:bg-slate-950/70"
+              style={{ zIndex: mobileDrawerZ.backdrop }}
+              className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm md:hidden dark:bg-slate-950/70"
             />
             <motion.nav
               initial={{ x: '-100%' }}
               animate={{ x: 0 }}
               exit={{ x: '-100%' }}
               transition={{ type: 'spring', bounce: 0, duration: 0.4 }}
-              className="fixed inset-y-0 left-0 w-72 bg-[var(--bg-surface)] flex flex-col z-50 md:hidden shadow-2xl border-r border-[var(--border-color)]"
+              style={{ zIndex: mobileDrawerZ.panel }}
+              className="fixed inset-y-0 left-0 w-72 bg-[var(--bg-surface)] flex flex-col md:hidden shadow-2xl border-r border-[var(--border-color)]"
             >
               <div className="px-6 py-8 border-b border-[var(--border-color)]">
                 <h1 className="text-2xl font-medium text-[var(--text-primary)]">天翼自动转存</h1>
@@ -363,7 +388,7 @@ export default function App() {
               <motion.button
                 type="button"
                 onClick={() => setIsThemeMenuOpen((currentState) => !currentState)}
-                whileHover={{ scale: 1.05, rotate: 15 }}
+                whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
                 className="p-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 transition-all duration-200 text-[var(--text-primary)]"
                 title={currentThemeLabel}
@@ -500,7 +525,7 @@ export default function App() {
           </div>
         </div>
 
-        <FloatingActions onAction={handleFloatingAction} />
+        {!isMobileMenuOpen && <FloatingActions onAction={handleFloatingAction} />}
       </main>
 
       {/* Modals */}

--- a/frontend/src/components/AIChat.tsx
+++ b/frontend/src/components/AIChat.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Bot, Send, Trash2, User } from 'lucide-react';
 import Modal from './Modal';
+import { useDialog } from './ui/Dialog';
 
 interface Message {
   id: number;
@@ -14,6 +15,7 @@ interface AIChatProps {
 }
 
 const AIChat: React.FC<AIChatProps> = ({ isOpen, onClose }) => {
+  const dialog = useDialog();
   const messageIdRef = useRef(1);
   const [messages, setMessages] = useState<Message[]>([
     { id: messageIdRef.current, role: 'assistant', content: '你好！我是天翼自动转存助理。你可以问我关于任务状态、账号容量或者如何配置订阅的问题。' }
@@ -150,7 +152,15 @@ const AIChat: React.FC<AIChatProps> = ({ isOpen, onClose }) => {
     };
   }, [isOpen]);
 
-  const resetChat = () => {
+  const resetChat = async () => {
+    if (messages.length <= 1) return;
+    const ok = await dialog.confirm({
+      title: '清空对话',
+      message: '确定清空当前对话记录吗？此操作不可恢复。',
+      confirmText: '清空',
+      tone: 'warning',
+    });
+    if (!ok) return;
     isStreamingRef.current = false;
     hasAssistantPlaceholderRef.current = false;
     setLoading(false);

--- a/frontend/src/components/CreateTaskModal.tsx
+++ b/frontend/src/components/CreateTaskModal.tsx
@@ -470,6 +470,40 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ isOpen, onClose, onSu
     if (submitting) {
       return;
     }
+
+    if (!formData.accountId) {
+      toast.warning('请先选择账号');
+      return;
+    }
+    if (isEditing) {
+      if (!formData.taskName.trim()) {
+        toast.warning('请填写任务名称');
+        return;
+      }
+      if (!formData.targetFolderId) {
+        toast.warning('请选择保存目录');
+        return;
+      }
+    } else if (isBatchMode) {
+      if (!formData.batchShareLinks.trim()) {
+        toast.warning('请填写批量分享链接（每行一条）');
+        return;
+      }
+      if (!formData.targetFolderId) {
+        toast.warning('请选择保存目录');
+        return;
+      }
+    } else {
+      if (!formData.shareLink.trim()) {
+        toast.warning('请填写分享链接');
+        return;
+      }
+      if (!formData.targetFolderId) {
+        toast.warning('请选择保存目录');
+        return;
+      }
+    }
+
     setSubmitting(true);
 
     try {
@@ -562,6 +596,7 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ isOpen, onClose, onSu
             lastTargetFolderName: formData.targetFolder
           })
         );
+        toast.success(isEditing ? '任务已保存' : isBatchMode ? '批量任务已提交' : '任务已创建');
         onSuccess();
         onClose();
       } else {
@@ -578,9 +613,36 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ isOpen, onClose, onSu
   const selectedAccount = accounts.find(account => String(account.id) === formData.accountId);
   const modalTitle = isEditing ? '修改任务' : (isBatchMode ? '批量创建任务' : '创建任务');
 
+  const formFooter = (
+    <div className="px-8 py-4 flex shrink-0 justify-end gap-3 border-t border-[var(--modal-border)] bg-[var(--modal-bg)]">
+      <button
+        type="button"
+        onClick={onClose}
+        className="px-6 py-3 bg-white border border-slate-300 text-slate-700 rounded-full font-medium hover:bg-slate-50 transition-all dark:bg-slate-800 dark:border-slate-600 dark:text-slate-100"
+      >
+        取消
+      </button>
+      <button
+        type="submit"
+        form="create-task-form"
+        disabled={submitting}
+        className="px-10 py-3 bg-[#0b57d0] text-white rounded-full font-medium shadow-lg hover:bg-[#0b57d0]/90 transition-all flex items-center gap-2 disabled:opacity-70"
+      >
+        {submitting ? <RefreshCw size={20} className="animate-spin" /> : <Check size={20} />}
+        {isEditing ? '保存修改' : (isBatchMode ? '开始批量创建' : '创建任务')}
+      </button>
+    </div>
+  );
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={modalTitle} footer={null}>
-      <form onSubmit={handleSubmit} className="space-y-6">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={modalTitle}
+      footer={formFooter}
+      contentClassName="px-8 pb-6 max-h-[min(70vh,640px)] overflow-y-auto custom-scrollbar"
+    >
+      <form id="create-task-form" onSubmit={handleSubmit} className="space-y-6">
         {!isEditing && (
           <div className="flex items-center justify-between bg-slate-50 p-1 rounded-2xl border border-slate-200">
             <button
@@ -967,23 +1029,6 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ isOpen, onClose, onSu
           </div>
         </div>
 
-        <div className="flex justify-end gap-3 pt-4">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-6 py-3 bg-white border border-slate-300 text-slate-700 rounded-full font-medium hover:bg-slate-50 transition-all"
-          >
-            取消
-          </button>
-          <button
-            type="submit"
-            disabled={submitting}
-            className="px-10 py-3 bg-[#0b57d0] text-white rounded-full font-medium shadow-lg hover:bg-[#0b57d0]/90 transition-all flex items-center gap-2 disabled:opacity-70"
-          >
-            {submitting ? <RefreshCw size={20} className="animate-spin" /> : <Check size={20} />}
-            {isEditing ? '保存修改' : (isBatchMode ? '开始批量创建' : '创建任务')}
-          </button>
-        </div>
       </form>
 
       <FolderSelector

--- a/frontend/src/components/FloatingActions.tsx
+++ b/frontend/src/components/FloatingActions.tsx
@@ -19,7 +19,7 @@ const FloatingActions: React.FC<FloatingActionsProps> = ({ onAction }) => {
     { id: 'createTask', icon: Plus, label: '创建任务', color: 'bg-[#0b57d0] text-white' },
     { id: 'cloudsaver', icon: Cpu, label: 'CloudSaver', color: 'bg-[#d3e3fd] text-[#0b57d0]' },
     { id: 'chat', icon: MessageSquare, label: 'AI 助手', color: 'bg-[#f3e8ff] text-[#7e22ce]' },
-    { id: 'strm', icon: Link2, label: 'STRM 生成', color: 'bg-[#c4eed0] text-[#146c2e]' },
+    { id: 'strm', icon: Link2, label: 'STRM 配置', color: 'bg-[#c4eed0] text-[#146c2e]' },
     { id: 'logs', icon: FileText, label: '实时日志', color: 'bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-100' },
   ];
 

--- a/frontend/src/components/FolderSelector.tsx
+++ b/frontend/src/components/FolderSelector.tsx
@@ -97,9 +97,14 @@ const FolderSelector: React.FC<FolderSelectorProps> = ({
       const data = await response.json();
       if (data.success) {
         setFolderEntries((data.data.entries || []).filter((e: any) => e.isFolder));
+      } else {
+        setFolderEntries([]);
+        toast.error(data.error || '加载目录失败');
       }
     } catch (error) {
       console.error('Failed to fetch folders:', error);
+      setFolderEntries([]);
+      toast.error('加载目录失败');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/LogConsole.tsx
+++ b/frontend/src/components/LogConsole.tsx
@@ -232,7 +232,7 @@ const LogConsole: React.FC<LogConsoleProps> = ({ isOpen, onClose }) => {
       onClose={onClose}
       title="系统实时日志"
       maxWidthClass="max-w-5xl"
-      contentClassName="px-5 md:px-8 pb-6 max-h-[70vh] overflow-y-auto custom-scrollbar"
+      contentClassName="px-5 md:px-8 pb-6 flex flex-col min-h-0 max-h-[min(70vh,640px)] overflow-hidden"
       footer={
         <div className="px-5 md:px-8 py-4 flex flex-col gap-4 border-t border-[var(--modal-border)] bg-white/70 dark:bg-slate-900/60 sm:flex-row sm:items-center sm:justify-between">
           <Checkbox
@@ -261,8 +261,8 @@ const LogConsole: React.FC<LogConsoleProps> = ({ isOpen, onClose }) => {
         </div>
       }
     >
-      <div className="space-y-4 pt-5">
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="space-y-4 pt-5 flex flex-col min-h-0 flex-1">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 shrink-0">
           <div className="rounded-2xl border border-[var(--modal-border)] bg-white px-4 py-3 dark:bg-slate-900/60">
             <div className="text-xs text-[var(--text-secondary)]">连接状态</div>
             <div className="mt-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
@@ -286,7 +286,7 @@ const LogConsole: React.FC<LogConsoleProps> = ({ isOpen, onClose }) => {
 
         <div
           ref={scrollRef}
-          className="h-[430px] overflow-y-auto rounded-2xl border border-[var(--modal-border)] bg-white p-3 custom-scrollbar dark:bg-slate-950/40"
+          className="h-[min(430px,50vh)] flex-1 min-h-[200px] overflow-y-auto rounded-2xl border border-[var(--modal-border)] bg-white p-3 custom-scrollbar dark:bg-slate-950/40"
         >
           {logs.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center text-center text-[var(--text-secondary)]">

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { X } from 'lucide-react';
 import { lockBodyScroll, unlockBodyScroll } from '../lib/bodyScrollLock';
-import { pushOverlay, popOverlay } from '../lib/overlayStack';
+import { pushOverlay, popOverlay, getOverlayZIndex } from '../lib/overlayStack';
 
 interface ModalProps {
   isOpen: boolean;
@@ -25,25 +26,41 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const [overlayId, setOverlayId] = useState<number | null>(null);
+  const [z, setZ] = useState({ backdrop: 200, panel: 201 });
 
   useEffect(() => {
     if (!isOpen) {
+      setOverlayId(null);
       return;
     }
 
     lockBodyScroll();
-    const overlayId = pushOverlay({
+    const id = pushOverlay({
       kind: 'modal',
       onEscape: () => onCloseRef.current()
     });
+    setOverlayId(id);
+    setZ(getOverlayZIndex(id, 'modal'));
 
     return () => {
-      popOverlay(overlayId);
+      popOverlay(id);
       unlockBodyScroll();
+      setOverlayId(null);
     };
   }, [isOpen]);
 
-  return (
+  // refresh z when stack depth changes after sibling opens
+  useEffect(() => {
+    if (overlayId == null) return;
+    setZ(getOverlayZIndex(overlayId, 'modal'));
+  }, [overlayId, isOpen]);
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
     <AnimatePresence>
       {isOpen && (
         <>
@@ -52,7 +69,8 @@ const Modal: React.FC<ModalProps> = ({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
-            className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-[200]"
+            style={{ zIndex: z.backdrop }}
+            className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm"
           />
           <motion.div
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
@@ -60,7 +78,8 @@ const Modal: React.FC<ModalProps> = ({
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             role="dialog"
             aria-modal="true"
-            className={`fixed left-1/2 top-1/2 flex max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col ${maxWidthClass} rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl z-[201] overflow-hidden`}
+            style={{ zIndex: z.panel }}
+            className={`fixed left-1/2 top-1/2 flex max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col ${maxWidthClass} rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl overflow-hidden`}
           >
             <div className="px-8 py-6 flex shrink-0 items-center justify-between border-b border-[var(--modal-border)]">
               <h3 className="text-2xl font-normal text-[var(--text-primary)]">{title}</h3>
@@ -101,7 +120,8 @@ const Modal: React.FC<ModalProps> = ({
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 };
 

--- a/frontend/src/components/tabs/AutoSeriesTab.tsx
+++ b/frontend/src/components/tabs/AutoSeriesTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Search, PlayCircle, RefreshCw, AlertCircle, CheckCircle2, X, ArrowLeft, Check } from 'lucide-react';
+import { Plus, PlayCircle, RefreshCw, AlertCircle, CheckCircle2, X, ArrowLeft, Check } from 'lucide-react';
 import Modal from '../Modal';
 import Checkbox from '../ui/Checkbox';
 import { useToast } from '../ui/Toast';
@@ -192,11 +192,11 @@ const AutoSeriesTab: React.FC = () => {
               </div>
             ) : (
               <p className="text-red-600 text-sm mt-1">
-                请先到“系统”页配置自动追剧默认账号和默认保存目录。
+                请先到「系统 → 任务设置」配置自动追剧默认账号和默认保存目录。
               </p>
             )}
           </div>
-          <button 
+          <button
             onClick={fetchData}
             className="p-2 hover:bg-slate-100 rounded-full transition-colors text-slate-500"
           >
@@ -205,39 +205,32 @@ const AutoSeriesTab: React.FC = () => {
         </div>
       </div>
 
-      <div className="flex items-center justify-between">
-        <button 
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <button
           onClick={() => setIsModalOpen(true)}
-          className="bg-[#0b57d0] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#0b57d0]/90 transition-all shadow-lg hover:shadow-xl flex items-center gap-2"
+          disabled={!isConfigured}
+          className="bg-[#0b57d0] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#0b57d0]/90 transition-all shadow-lg hover:shadow-xl flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Plus size={20} /> 添加追剧
         </button>
-        <div className="relative w-72">
-          <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
-          <input 
-            type="text" 
-            placeholder="搜索剧集..." 
-            className="pl-12 pr-4 py-3 bg-white border border-slate-200 rounded-full text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20 w-full shadow-sm"
-          />
-        </div>
+        <p className="text-sm text-slate-500 flex items-center gap-2">
+          <AlertCircle size={16} className="shrink-0 text-slate-400" />
+          本页仅提供快速创建入口；已创建的任务请到「任务」页管理。
+        </p>
       </div>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {/* Placeholder cards to show design */}
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 shadow-sm group hover:shadow-md transition-all">
-          <div className="flex items-start justify-between mb-6">
-            <div className="w-16 h-16 rounded-2xl bg-[#d3e3fd] flex items-center justify-center text-[#0b57d0] group-hover:scale-110 transition-transform">
-              <PlayCircle size={32} />
-            </div>
-            <span className="px-4 py-1.5 bg-[#c4eed0] text-[#0d4f1f] rounded-full text-xs font-bold uppercase tracking-wider">自动追剧中</span>
+
+      <div className="bg-white rounded-3xl border border-slate-200/60 p-8 shadow-sm">
+        <div className="flex items-start gap-5">
+          <div className="w-14 h-14 rounded-2xl bg-[#d3e3fd] flex items-center justify-center text-[#0b57d0] shrink-0">
+            <PlayCircle size={28} />
           </div>
-          <h3 className="font-bold text-slate-900 text-xl mb-1">通过添加任务启动</h3>
-          <p className="text-sm text-slate-500">点击上方按钮，输入想追的剧名</p>
-          <div className="mt-8 pt-6 border-t border-slate-100">
-            <div className="flex items-center gap-2 text-slate-400 text-xs">
-              <AlertCircle size={14} />
-              <span>本页仅提供快速创建功能</span>
-            </div>
+          <div className="min-w-0 space-y-2">
+            <h3 className="font-bold text-slate-900 text-lg">如何自动追剧</h3>
+            <ol className="text-sm text-slate-600 space-y-1.5 list-decimal list-inside leading-relaxed">
+              <li>在「系统 → 任务设置」填好默认账号与保存目录</li>
+              <li>点击上方「添加追剧」，搜索并选定资源</li>
+              <li>确认后会创建转存任务，后续追更在「任务」页查看</li>
+            </ol>
           </div>
         </div>
       </div>

--- a/frontend/src/components/tabs/CasTab.tsx
+++ b/frontend/src/components/tabs/CasTab.tsx
@@ -20,6 +20,8 @@ import {
 } from 'lucide-react';
 import FolderSelector, { SelectedFolder } from '../FolderSelector';
 import type { TabType } from '../../App';
+import { useDialog } from '../ui/Dialog';
+import { useToast } from '../ui/Toast';
 
 interface Account {
   id: number;
@@ -109,6 +111,17 @@ const statusClass = (status: string) => {
 };
 
 const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
+  const dialog = useDialog();
+  const toast = useToast();
+  const notify = (message: string, type: 'success' | 'error' | 'info' = 'info') => {
+    if (onShowToast) {
+      onShowToast(message, type);
+      return;
+    }
+    if (type === 'success') toast.success(message);
+    else if (type === 'error') toast.error(message);
+    else toast.info(message);
+  };
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null);
   const [config, setConfig] = useState<CasConfig>({
@@ -273,7 +286,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
   const handleRestore = async () => {
     if (isRestoring) return;
     if (!selectedAccountId || !casContent || !targetFolder) {
-      onShowToast?.('请选择账号、填写存根内容并选择目标目录', 'error');
+      notify('请选择账号、填写存根内容并选择目标目录', 'error');
       return;
     }
 
@@ -291,15 +304,15 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       });
       const data = await res.json();
       if (data.success) {
-        onShowToast?.(`秒传恢复成功: ${data.data.name}`, 'success');
+        notify(`秒传恢复成功: ${data.data.name}`, 'success');
         setCasContent('');
         setRestoreName('');
         setTargetFolder(null);
       } else {
-        onShowToast?.('恢复失败: ' + (data.error || '未知错误'), 'error');
+        notify('恢复失败: ' + (data.error || '未知错误'), 'error');
       }
     } catch (e) {
-      onShowToast?.('操作过程中发生错误', 'error');
+      notify('操作过程中发生错误', 'error');
     } finally {
       setIsRestoring(false);
     }
@@ -308,7 +321,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
   const handleImport = async () => {
     if (isImporting) return;
     if (!selectedAccountId || !importFolder || !selectedFile) {
-      onShowToast?.('请选择账号、目标目录并选择 .cas/.zip/.rar 文件', 'error');
+      notify('请选择账号、目标目录并选择 .cas/.zip/.rar 文件', 'error');
       return;
     }
 
@@ -334,7 +347,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       });
       const data = await res.json();
       if (data.success) {
-        onShowToast?.(`导入任务已创建: ${data.data.title}`, 'success');
+        notify(`导入任务已创建: ${data.data.title}`, 'success');
         setSelectedFile(null);
         setImportTitle('');
         if (fileInputRef.current) fileInputRef.current.value = '';
@@ -342,10 +355,10 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
         await fetchJobs();
         await fetchJobDetail(data.data.id);
       } else {
-        onShowToast?.('导入失败: ' + (data.error || '未知错误'), 'error');
+        notify('导入失败: ' + (data.error || '未知错误'), 'error');
       }
     } catch (e) {
-      onShowToast?.('上传过程中发生错误', 'error');
+      notify('上传过程中发生错误', 'error');
     } finally {
       setIsImporting(false);
     }
@@ -358,25 +371,42 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       const res = await fetch(`/api/cas/import/jobs/${encodeURIComponent(jobId)}/retry`, { method: 'POST' });
       const data = await res.json();
       if (data.success) {
-        onShowToast?.('已开始重试失败项', 'success');
+        notify('已开始重试失败项', 'success');
         setActiveJobId(jobId);
         fetchJobs();
         fetchJobDetail(jobId);
       } else {
-        onShowToast?.(data.error || '重试失败', 'error');
+        notify(data.error || '重试失败', 'error');
       }
     } catch (e) {
-      onShowToast?.('重试失败', 'error');
+      notify('重试失败', 'error');
     } finally {
       setRetryingJobIds((ids) => ids.filter((id) => id !== jobId));
     }
   };
 
   const handleDeleteJob = async (job: ImportJobSummary) => {
-    if (!window.confirm(`确认删除导入任务「${job.title}」？`)) {
-      return;
+    const ok = await dialog.confirm({
+      title: '删除导入任务',
+      message: job.strmRoot
+        ? `确认删除导入任务「${job.title}」？\n若该任务生成过 STRM，下一步可选择是否一并删除。`
+        : `确认删除导入任务「${job.title}」？`,
+      confirmText: '删除',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    let alsoDeleteStrm = false;
+    if (job.strmRoot) {
+      alsoDeleteStrm = await dialog.confirm({
+        title: '同时删除 STRM？',
+        message: '是否同时删除该任务生成的 STRM 目录？',
+        confirmText: '一并删除',
+        cancelText: '仅删任务',
+        tone: 'warning',
+      });
     }
-    const alsoDeleteStrm = !!job.strmRoot && window.confirm('是否同时删除该任务生成的 STRM 目录？');
+
     try {
       const res = await fetch(
         `/api/cas/import/jobs/${encodeURIComponent(job.id)}?deleteStrm=${alsoDeleteStrm ? '1' : '0'}`,
@@ -384,7 +414,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       );
       const data = await res.json();
       if (data.success) {
-        onShowToast?.('任务已删除', 'success');
+        notify('任务已删除', 'success');
         if (activeJobId === job.id) {
           setActiveJobId(null);
           setActiveJob(null);
@@ -392,10 +422,10 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
         fetchJobs();
         fetchStrmList(strmPath);
       } else {
-        onShowToast?.(data.error || '删除失败', 'error');
+        notify(data.error || '删除失败', 'error');
       }
     } catch (e) {
-      onShowToast?.('删除失败', 'error');
+      notify('删除失败', 'error');
     }
   };
 
@@ -411,22 +441,28 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       });
       const data = await res.json();
       if (data.success) {
-        onShowToast?.(all ? '已清理全部分享缓存' : '已清理缓存', 'success');
+        notify(all ? '已清理全部分享缓存' : '已清理缓存', 'success');
         fetchShareCaches();
       } else {
-        onShowToast?.(data.error || '清理失败', 'error');
+        notify(data.error || '清理失败', 'error');
       }
     } catch (e) {
-      onShowToast?.('清理失败', 'error');
+      notify('清理失败', 'error');
     }
   };
 
   const handleDeleteStrm = async (item: StrmListItem) => {
     if (item.type !== 'directory') {
-      onShowToast?.('当前仅支持删除目录', 'info');
+      notify('当前仅支持删除目录', 'info');
       return;
     }
-    if (!window.confirm(`确认删除 STRM 目录：${item.path}？`)) return;
+    const ok = await dialog.confirm({
+      title: '删除 STRM 目录',
+      message: `确认删除 STRM 目录：${item.path}？`,
+      confirmText: '删除',
+      tone: 'danger',
+    });
+    if (!ok) return;
     try {
       const res = await fetch('/api/cas/import/strm', {
         method: 'DELETE',
@@ -435,19 +471,19 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       });
       const data = await res.json();
       if (data.success) {
-        onShowToast?.('STRM 目录已删除', 'success');
+        notify('STRM 目录已删除', 'success');
         fetchStrmList(strmPath);
       } else {
-        onShowToast?.(data.error || '删除失败', 'error');
+        notify(data.error || '删除失败', 'error');
       }
     } catch (e) {
-      onShowToast?.('删除失败', 'error');
+      notify('删除失败', 'error');
     }
   };
 
   const openFolderSelector = (mode: 'restore' | 'import') => {
     if (!selectedAccountId) {
-      onShowToast?.('请先选择账号', 'error');
+      notify('请先选择账号', 'error');
       return;
     }
     setFolderSelectorMode(mode);
@@ -580,7 +616,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                   }
                   const lower = file.name.toLowerCase();
                   if (!(lower.endsWith('.cas') || lower.endsWith('.zip') || lower.endsWith('.rar'))) {
-                    onShowToast?.('仅支持 .cas / .zip / .rar 文件', 'error');
+                    notify('仅支持 .cas / .zip / .rar 文件', 'error');
                     e.target.value = '';
                     setSelectedFile(null);
                     return;
@@ -916,8 +952,14 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                 刷新
               </button>
               <button
-                onClick={() => {
-                  if (window.confirm('确认清理全部分享 CAS 元数据缓存？')) {
+                onClick={async () => {
+                  const ok = await dialog.confirm({
+                    title: '清理分享缓存',
+                    message: '确认清理全部分享 CAS 元数据缓存？',
+                    confirmText: '全部清理',
+                    tone: 'danger',
+                  });
+                  if (ok) {
                     handleClearShareCache(undefined, true);
                   }
                 }}

--- a/frontend/src/components/tabs/FileManagerTab.tsx
+++ b/frontend/src/components/tabs/FileManagerTab.tsx
@@ -356,17 +356,28 @@ const FileManagerTab: React.FC = () => {
     setSelectedIds(newSelected);
   };
 
-  const handleSelectAll = (checked: boolean) => {
-    if (checked) {
-      setSelectedIds(new Set(visibleEntries.map(e => e.id)));
-    } else {
-      setSelectedIds(new Set());
-    }
-  };
-
   const visibleEntries = entries.filter(e =>
     e.name.toLowerCase().includes(filterKeyword.toLowerCase())
   );
+  const visibleSelectedCount = visibleEntries.filter((e) => selectedIds.has(e.id)).length;
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      // 并入可见项，保留筛选外已选
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        visibleEntries.forEach((e) => next.add(e.id));
+        return next;
+      });
+    } else {
+      // 只取消当前可见项
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        visibleEntries.forEach((e) => next.delete(e.id));
+        return next;
+      });
+    }
+  };
 
   const selectedEntries = entries.filter(e => selectedIds.has(e.id));
   const selectedFolders = selectedEntries.filter((entry) => entry.isFolder);
@@ -546,8 +557,8 @@ const FileManagerTab: React.FC = () => {
                   <Checkbox
                     size="sm"
                     onChange={handleSelectAll}
-                    checked={visibleEntries.length > 0 && selectedIds.size === visibleEntries.length}
-                    indeterminate={selectedIds.size > 0 && selectedIds.size < visibleEntries.length}
+                    checked={visibleEntries.length > 0 && visibleSelectedCount === visibleEntries.length}
+                    indeterminate={visibleSelectedCount > 0 && visibleSelectedCount < visibleEntries.length}
                   />
                 </th>
                 <th className="px-6 py-4 font-medium text-slate-500">名称</th>

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -508,10 +508,12 @@ const MediaTab: React.FC = () => {
         </h3>
         <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
           <div className="flex flex-col gap-4">
-            <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
+            <label
+              className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors"
+              onClick={() => updateSetting('cas.enableFamilyTransit', !settings.cas.enableFamilyTransit)}
+            >
               <div
-                onClick={() => updateSetting('cas.enableFamilyTransit', !settings.cas.enableFamilyTransit)}
-                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all ${
+                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all shrink-0 ${
                   settings.cas.enableFamilyTransit ? 'bg-[#0b57d0] border-[#0b57d0]' : 'border-slate-300 bg-white'
                 }`}
               >
@@ -522,10 +524,12 @@ const MediaTab: React.FC = () => {
                 <p className="text-[10px] text-slate-400">秒传时通过家庭云中转，规避个人云风控</p>
               </div>
             </label>
-            <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
+            <label
+              className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors"
+              onClick={() => updateSetting('cas.familyTransitFirst', !settings.cas.familyTransitFirst)}
+            >
               <div
-                onClick={() => updateSetting('cas.familyTransitFirst', !settings.cas.familyTransitFirst)}
-                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all ${
+                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all shrink-0 ${
                   settings.cas.familyTransitFirst ? 'bg-[#0b57d0] border-[#0b57d0]' : 'border-slate-300 bg-white'
                 }`}
               >
@@ -536,10 +540,12 @@ const MediaTab: React.FC = () => {
                 <p className="text-[10px] text-slate-400">默认先尝试家庭云秒传，失败再回退个人云</p>
               </div>
             </label>
-            <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
+            <label
+              className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors"
+              onClick={() => updateSetting('cas.deleteCasAfterRestore', !settings.cas.deleteCasAfterRestore)}
+            >
               <div
-                onClick={() => updateSetting('cas.deleteCasAfterRestore', !settings.cas.deleteCasAfterRestore)}
-                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all ${
+                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all shrink-0 ${
                   settings.cas.deleteCasAfterRestore ? 'bg-[#0b57d0] border-[#0b57d0]' : 'border-slate-300 bg-white'
                 }`}
               >
@@ -550,10 +556,12 @@ const MediaTab: React.FC = () => {
                 <p className="text-[10px] text-slate-400">秒传恢复成功后自动删除 .cas 存根文件</p>
               </div>
             </label>
-            <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
+            <label
+              className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors"
+              onClick={() => updateSetting('cas.deleteSourceAfterGenerate', !settings.cas.deleteSourceAfterGenerate)}
+            >
               <div
-                onClick={() => updateSetting('cas.deleteSourceAfterGenerate', !settings.cas.deleteSourceAfterGenerate)}
-                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all ${
+                className={`w-6 h-6 rounded-lg border flex items-center justify-center transition-all shrink-0 ${
                   settings.cas.deleteSourceAfterGenerate ? 'bg-[#0b57d0] border-[#0b57d0]' : 'border-slate-300 bg-white'
                 }`}
               >

--- a/frontend/src/components/tabs/OrganizerTab.tsx
+++ b/frontend/src/components/tabs/OrganizerTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Play, Search, RefreshCw, Clock, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { useToast } from '../ui/Toast';
 
@@ -24,21 +24,36 @@ const OrganizerTab: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [runningTaskIds, setRunningTaskIds] = useState<number[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const fetchTasks = useCallback(async () => {
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(searchTerm.trim());
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchTerm]);
+
+  const fetchTasks = useCallback(async (keyword = debouncedSearch) => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/organizer/tasks?search=${encodeURIComponent(searchTerm)}`);
+      const response = await fetch(`/api/organizer/tasks?search=${encodeURIComponent(keyword)}`);
       const data = await response.json();
       if (data.success) {
         setTasks(data.data || []);
+      } else {
+        toast.error(data.error || '加载整理任务失败');
       }
     } catch (error) {
       console.error('Failed to fetch organizer tasks:', error);
+      toast.error('加载整理任务失败');
     } finally {
       setLoading(false);
     }
-  }, [searchTerm]);
+  }, [debouncedSearch, toast]);
 
   useEffect(() => {
     fetchTasks();
@@ -76,17 +91,22 @@ const OrganizerTab: React.FC = () => {
         <div className="flex items-center gap-3">
           <div className="relative w-64">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={16} />
-            <input 
-              type="text" 
-              placeholder="搜索任务..." 
+            <input
+              type="text"
+              placeholder="搜索任务..."
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && fetchTasks()}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  if (debounceRef.current) clearTimeout(debounceRef.current);
+                  setDebouncedSearch(searchTerm.trim());
+                }
+              }}
               className="pl-10 pr-4 py-2 bg-white border border-slate-300 rounded-full text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20 w-full"
             />
           </div>
-          <button 
-            onClick={fetchTasks}
+          <button
+            onClick={() => fetchTasks()}
             className="p-2 bg-white border border-slate-300 rounded-full hover:bg-slate-50 transition-all text-slate-600 shadow-sm"
           >
             <RefreshCw size={20} className={loading ? 'animate-spin' : ''} />
@@ -120,44 +140,53 @@ const OrganizerTab: React.FC = () => {
                   <td colSpan={6} className="px-6 py-12 text-center text-slate-500">暂无任务</td>
                 </tr>
               ) : (
-                tasks.map(task => {
-                  const taskName = task.shareFolderName ? `${task.resourceName}/${task.shareFolderName}` : task.resourceName || '未知';
+                tasks.map((task) => {
+                  const isRunning = runningTaskIds.includes(task.id);
                   return (
-                    <tr key={task.id} className="hover:bg-slate-50/50 transition-colors group">
+                    <tr key={task.id} className="hover:bg-slate-50/50 transition-colors">
                       <td className="px-6 py-4">
-                        <button 
-                          onClick={() => handleRunTask(task.id)} disabled={runningTaskIds.includes(task.id)}
-                          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#d3e3fd] text-[#0b57d0] rounded-lg text-xs font-bold hover:bg-[#c2e7ff] transition-colors"
+                        <button
+                          onClick={() => handleRunTask(task.id)}
+                          disabled={isRunning}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-[#0b57d0] text-white hover:bg-[#0b57d0]/90 disabled:opacity-50"
                         >
-                          <Play size={14} fill="currentColor" /> 执行整理
+                          {isRunning ? <RefreshCw size={14} className="animate-spin" /> : <Play size={14} />}
+                          {isRunning ? '执行中' : '执行整理'}
                         </button>
                       </td>
-                      <td className="px-6 py-4 font-medium text-slate-900">{taskName}</td>
-                      <td className="px-6 py-4 text-slate-500">
-                        {task.account.username}
-                        <span className="ml-1 text-[10px] bg-slate-100 px-1.5 py-0.5 rounded uppercase">
-                          {task.account.accountType === 'family' ? '家庭' : '个人'}
+                      <td className="px-6 py-4 font-medium text-slate-900">
+                        <div>{task.resourceName}</div>
+                        {task.shareFolderName && (
+                          <div className="text-xs text-slate-400 mt-0.5">{task.shareFolderName}</div>
+                        )}
+                      </td>
+                      <td className="px-6 py-4 text-slate-600">
+                        {task.account?.username || '-'}
+                        <span className="ml-1 text-xs text-slate-400">
+                          ({task.account?.accountType === 'family' ? '家庭云' : '个人云'})
                         </span>
                       </td>
                       <td className="px-6 py-4">
                         {task.enableOrganizer ? (
-                          <span className="flex items-center gap-1 text-[#146c2e]">
+                          <span className="inline-flex items-center gap-1 text-emerald-600 text-xs font-medium">
                             <CheckCircle2 size={14} /> 已启用
                           </span>
                         ) : (
-                          <span className="flex items-center gap-1 text-slate-400">
+                          <span className="inline-flex items-center gap-1 text-slate-400 text-xs font-medium">
                             <Clock size={14} /> 未启用
                           </span>
                         )}
                       </td>
-                      <td className="px-6 py-4 text-slate-500">{formatDateTime(task.lastOrganizedAt)}</td>
-                      <td className="px-6 py-4">
+                      <td className="px-6 py-4 text-slate-500 text-xs whitespace-nowrap">
+                        {formatDateTime(task.lastOrganizedAt)}
+                      </td>
+                      <td className="px-6 py-4 text-xs text-red-500 max-w-[200px] truncate" title={task.lastOrganizeError || ''}>
                         {task.lastOrganizeError ? (
-                          <span className="flex items-center gap-1 text-red-600 truncate max-w-[200px]" title={task.lastOrganizeError}>
-                            <AlertCircle size={14} /> {task.lastOrganizeError}
+                          <span className="inline-flex items-center gap-1">
+                            <AlertCircle size={12} /> {task.lastOrganizeError}
                           </span>
                         ) : (
-                          <span className="text-slate-300">-</span>
+                          <span className="text-slate-300">—</span>
                         )}
                       </td>
                     </tr>

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -7,6 +7,12 @@ import Switch from '../ui/Switch';
 import { useToast } from '../ui/Toast';
 import { useDialog } from '../ui/Dialog';
 
+const parseIntOr = (raw: string, fallback: number) => {
+  if (raw === '' || raw === '-' ) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+};
+
 interface CustomPushConfig {
   name: string;
   description: string;
@@ -665,7 +671,7 @@ const SettingsTab: React.FC = () => {
               <input 
                 type="number" 
                 value={settings.task.taskExpireDays}
-                onChange={(e) => updateSettings('task.taskExpireDays', parseInt(e.target.value))}
+                onChange={(e) => updateSettings('task.taskExpireDays', parseIntOr(e.target.value, 15))}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -674,7 +680,7 @@ const SettingsTab: React.FC = () => {
               <input 
                 type="number" 
                 value={settings.task.maxRetries}
-                onChange={(e) => updateSettings('task.maxRetries', parseInt(e.target.value))}
+                onChange={(e) => updateSettings('task.maxRetries', parseIntOr(e.target.value, 3))}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -683,7 +689,7 @@ const SettingsTab: React.FC = () => {
               <input 
                 type="number" 
                 value={settings.task.retryInterval}
-                onChange={(e) => updateSettings('task.retryInterval', parseInt(e.target.value))}
+                onChange={(e) => updateSettings('task.retryInterval', parseIntOr(e.target.value, 5))}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -730,7 +736,7 @@ const SettingsTab: React.FC = () => {
               <input 
                 type="number" 
                 value={settings.task.lazyFileRetentionHours}
-                onChange={(e) => updateSettings('task.lazyFileRetentionHours', parseInt(e.target.value))}
+                onChange={(e) => updateSettings('task.lazyFileRetentionHours', parseIntOr(e.target.value, 24))}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
             </div>
@@ -1226,7 +1232,7 @@ const SettingsTab: React.FC = () => {
               <input 
                 type="number" 
                 value={settings.proxy.port}
-                onChange={(e) => updateSettings('proxy.port', parseInt(e.target.value))}
+                onChange={(e) => updateSettings('proxy.port', parseIntOr(e.target.value, 0))}
                 placeholder="7890"
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -5,6 +5,7 @@ import FolderSelector, { SelectedFolder } from '../FolderSelector';
 import Checkbox from '../ui/Checkbox';
 import Switch from '../ui/Switch';
 import { useToast } from '../ui/Toast';
+import { useDialog } from '../ui/Dialog';
 
 interface CustomPushConfig {
   name: string;
@@ -256,6 +257,7 @@ const initialSettings: SettingsData = {
 
 const SettingsTab: React.FC = () => {
   const toast = useToast();
+  const dialog = useDialog();
   const [settings, setSettings] = useState<SettingsData>(initialSettings);
   const [accounts, setAccounts] = useState<{id: number, username: string, alias?: string}[]>([]);
   const [loading, setLoading] = useState(true);
@@ -564,8 +566,14 @@ const SettingsTab: React.FC = () => {
     setIsPushModalOpen(false);
   };
 
-  const deletePushConfig = (index: number) => {
-    if (!confirm('确定删除此推送配置吗？')) return;
+  const deletePushConfig = async (index: number) => {
+    const ok = await dialog.confirm({
+      title: '删除推送配置',
+      message: '确定删除此推送配置吗？',
+      confirmText: '删除',
+      tone: 'danger',
+    });
+    if (!ok) return;
     const newConfigs = settings.customPush.filter((_, i) => i !== index);
     updateSettings('customPush', newConfigs);
   };
@@ -1569,8 +1577,14 @@ const SettingsTab: React.FC = () => {
                     </button>
                     <button 
                       type="button"
-                      onClick={() => {
-                        if (!confirm('确定删除此正则预设吗？')) return;
+                      onClick={async () => {
+                        const ok = await dialog.confirm({
+                          title: '删除正则预设',
+                          message: '确定删除此正则预设吗？',
+                          confirmText: '删除',
+                          tone: 'danger',
+                        });
+                        if (!ok) return;
                         const newPresets = settings.regexPresets!.filter((_, i) => i !== index);
                         updateSettings('regexPresets', newPresets);
                       }}

--- a/frontend/src/components/tabs/StrmConfigTab.tsx
+++ b/frontend/src/components/tabs/StrmConfigTab.tsx
@@ -75,6 +75,7 @@ const StrmConfigTab: React.FC = () => {
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [resources, setResources] = useState<Resource[]>([]);
   const [loading, setLoading] = useState(true);
+  const [openMenuId, setOpenMenuId] = useState<number | null>(null);
 
   // Modal State
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -171,6 +172,18 @@ const StrmConfigTab: React.FC = () => {
     fetchAccounts();
     fetchSubscriptions();
   }, []);
+
+  useEffect(() => {
+    if (openMenuId == null) return;
+    const onDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target?.closest('[data-strm-menu]')) {
+        setOpenMenuId(null);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [openMenuId]);
 
   useEffect(() => {
     if (formData.subscriptionId) {
@@ -524,32 +537,52 @@ const StrmConfigTab: React.FC = () => {
                       >
                         <Edit2 size={18} />
                       </button>
-                      <div className="relative group/menu">
-                        <button className="p-2 hover:bg-slate-100 rounded-full text-slate-500 transition-colors">
+                      <div className="relative" data-strm-menu>
+                        <button
+                          type="button"
+                          onClick={() => setOpenMenuId((prev) => (prev === config.id ? null : config.id))}
+                          className="p-2 hover:bg-slate-100 rounded-full text-slate-500 transition-colors"
+                          aria-label="更多操作"
+                          aria-expanded={openMenuId === config.id}
+                        >
                           <MoreVertical size={18} />
                         </button>
-                        <div className="absolute right-0 top-full mt-1 w-32 bg-white rounded-xl shadow-lg border border-slate-100 py-1 hidden group-hover/menu:block z-[210]">
-                          <button 
-                            onClick={() => handleToggleConfig(config)}
-                            className={`w-full px-4 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2 ${config.enabled ? 'text-orange-600' : 'text-green-600'}`}
-                          >
-                            {config.enabled ? '停用' : '启用'}
-                          </button>
-                          {config.type === 'subscription' && (
-                            <button 
-                              onClick={() => handleResetTime(config.id)}
-                              className="w-full px-4 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2 text-slate-700"
+                        {openMenuId === config.id && (
+                          <div className="absolute right-0 top-full mt-1 w-36 bg-white rounded-xl shadow-lg border border-slate-100 py-1 z-[210] dark:bg-slate-900 dark:border-slate-700">
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setOpenMenuId(null);
+                                handleToggleConfig(config);
+                              }}
+                              className={`w-full px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800 flex items-center gap-2 ${config.enabled ? 'text-orange-600' : 'text-green-600'}`}
                             >
-                              <RefreshCw size={14} /> 重置时间
+                              {config.enabled ? '停用' : '启用'}
                             </button>
-                          )}
-                          <button 
-                            onClick={() => handleDeleteConfig(config.id)}
-                            className="w-full px-4 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2 text-red-600"
-                          >
-                            <Trash2 size={14} /> 删除
-                          </button>
-                        </div>
+                            {config.type === 'subscription' && (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setOpenMenuId(null);
+                                  handleResetTime(config.id);
+                                }}
+                                className="w-full px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800 flex items-center gap-2 text-slate-700 dark:text-slate-200"
+                              >
+                                <RefreshCw size={14} /> 重置时间
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setOpenMenuId(null);
+                                handleDeleteConfig(config.id);
+                              }}
+                              className="w-full px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800 flex items-center gap-2 text-red-600"
+                            >
+                              <Trash2 size={14} /> 删除
+                            </button>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </td>

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -308,8 +308,10 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const handleDeleteTask = async (id: number) => {
     const ok = await dialog.confirm({
       title: '删除任务',
-      message: deleteCloud ? '确定要删除这个任务并且从网盘中也删除吗？' : '确定要删除这个任务吗？',
-      confirmText: '删除',
+      message: deleteCloud
+        ? '确定删除这个任务，并同步从网盘删除对应文件？此操作不可恢复。'
+        : '确定删除这个任务记录吗？（默认只删任务，不删网盘。如需同步删网盘，请先勾选工具条「同步删除网盘」。）',
+      confirmText: deleteCloud ? '删除任务和网盘' : '删除',
       tone: 'danger',
     });
     if (!ok) return;
@@ -321,10 +323,14 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       });
       const data = await response.json();
       if (data.success) {
+        toast.success(deleteCloud ? '任务已删除（含网盘）' : '任务已删除');
         fetchTasks();
+      } else {
+        toast.error(data.error || '删除失败');
       }
     } catch (error) {
       console.error('Failed to delete task:', error);
+      toast.error('删除失败');
     }
   };
 
@@ -437,10 +443,13 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
 
   const handleBatchDelete = async () => {
     if (selectedTaskIds.length === 0) return;
+    const count = selectedTaskIds.length;
     const ok = await dialog.confirm({
       title: '批量删除任务',
-      message: deleteCloud ? '确定要删除选中任务并且从网盘中也删除吗？' : '确定要删除选中的任务吗？',
-      confirmText: '删除',
+      message: deleteCloud
+        ? `确定删除选中的 ${count} 个任务，并同步从网盘删除对应文件？此操作不可恢复。`
+        : `确定删除选中的 ${count} 个任务记录吗？（默认只删任务。如需同步删网盘，请先勾选「同步删除网盘」。）`,
+      confirmText: deleteCloud ? '删除任务和网盘' : '删除',
       tone: 'danger',
     });
     if (!ok) return;
@@ -452,11 +461,15 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       });
       const data = await response.json();
       if (data.success) {
+        toast.success(deleteCloud ? `已删除 ${count} 个任务（含网盘）` : `已删除 ${count} 个任务`);
         setSelectedTaskIds([]);
         fetchTasks();
+      } else {
+        toast.error(data.error || '批量删除失败');
       }
     } catch (error) {
       console.error('Failed to batch delete tasks:', error);
+      toast.error('批量删除失败');
     }
   };
 
@@ -472,12 +485,14 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       });
       const data = await response.json();
       if (data.success) {
+        toast.success(`已更新 ${selectedTaskIds.length} 个任务状态`);
         fetchTasks();
       } else {
         toast.error(data.error || '批量更新状态失败');
       }
     } catch (error) {
       console.error('Failed to batch update task status:', error);
+      toast.error('批量更新状态失败');
     } finally {
       setIsBatchUpdatingStatus(false);
     }
@@ -777,9 +792,15 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
           </div>
         )}
 
-        <label className="flex items-center gap-2 cursor-pointer group">
+        <label
+          className={`flex items-center gap-2 cursor-pointer group select-none rounded-full px-3 py-1.5 border transition-colors ${
+            deleteCloud
+              ? 'border-red-300 bg-red-50 text-red-700'
+              : 'border-transparent text-slate-600'
+          }`}
+          onClick={() => setDeleteCloud((prev) => !prev)}
+        >
           <div
-            onClick={() => setDeleteCloud(!deleteCloud)}
             className={`w-4 h-4 rounded border flex items-center justify-center transition-colors ${
               deleteCloud
                 ? 'bg-red-500 border-red-500'
@@ -788,7 +809,9 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
           >
             {deleteCloud && <div className="w-2 h-2 bg-white rounded-sm" />}
           </div>
-          <span className="text-sm font-medium text-slate-600">同步删除网盘</span>
+          <span className="text-sm font-medium">
+            {deleteCloud ? '已开启：删除任务将同步删网盘' : '同步删除网盘'}
+          </span>
         </label>
       </div>
 

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState, ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import { AlertTriangle, HelpCircle, Info, AlertOctagon } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Info, AlertOctagon } from 'lucide-react';
 import { lockBodyScroll, unlockBodyScroll } from '../../lib/bodyScrollLock';
-import { pushOverlay, popOverlay, updateOverlay } from '../../lib/overlayStack';
+import { pushOverlay, popOverlay, updateOverlay, getOverlayZIndex } from '../../lib/overlayStack';
 
 export type DialogTone = 'info' | 'danger' | 'warning' | 'success';
 
@@ -45,7 +45,7 @@ const toneIconMap: Record<DialogTone, typeof AlertTriangle> = {
   info: Info,
   warning: AlertTriangle,
   danger: AlertOctagon,
-  success: HelpCircle,
+  success: CheckCircle2 as typeof AlertTriangle,
 };
 
 const toneStyleMap: Record<DialogTone, { iconBg: string; iconColor: string; confirmBg: string }> = {
@@ -173,6 +173,9 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
     }
   }, [type]);
 
+  const overlayIdRef = useRef<number | null>(null);
+  const [z, setZ] = useState({ backdrop: 400, panel: 401 });
+
   useEffect(() => {
     lockBodyScroll();
     const overlayId = pushOverlay({
@@ -180,18 +183,23 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
       onEscape: handleCancel,
       onEnter: type === 'prompt' && options.multiline ? undefined : handleConfirm,
     });
+    overlayIdRef.current = overlayId;
+    setZ(getOverlayZIndex(overlayId, 'dialog'));
 
     return () => {
       popOverlay(overlayId);
       unlockBodyScroll();
+      overlayIdRef.current = null;
     };
   }, [handleCancel, handleConfirm, type, options.multiline]);
 
   useEffect(() => {
-    // keep handlers fresh for stack top without re-register churn beyond deps above
-  }, []);
-
-  void updateOverlay;
+    if (overlayIdRef.current == null) return;
+    updateOverlay(overlayIdRef.current, {
+      onEscape: handleCancel,
+      onEnter: type === 'prompt' && options.multiline ? undefined : handleConfirm,
+    });
+  }, [handleCancel, handleConfirm, type, options.multiline]);
 
   const confirmText = options.confirmText ?? (type === 'prompt' ? '确定' : type === 'alert' ? '知道了' : '确认');
   const cancelText = options.cancelText ?? '取消';
@@ -203,7 +211,8 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         onClick={handleCancel}
-        className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-[400]"
+        style={{ zIndex: z.backdrop }}
+        className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm"
       />
       <motion.div
         initial={{ opacity: 0, scale: 0.95, y: 20 }}
@@ -212,7 +221,8 @@ const DialogRenderer: React.FC<RendererProps> = ({ dialog, onClose }) => {
         transition={{ type: 'spring', stiffness: 380, damping: 30 }}
         role="dialog"
         aria-modal="true"
-        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] max-w-md rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl z-[401] overflow-hidden"
+        style={{ zIndex: z.panel }}
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] max-w-md rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl overflow-hidden"
       >
         <div className="px-6 pt-6 pb-2 flex items-start gap-4">
           {options.icon !== null && (

--- a/frontend/src/components/ui/Switch.tsx
+++ b/frontend/src/components/ui/Switch.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useId } from 'react';
 
 interface SwitchProps {
   checked: boolean;
@@ -33,38 +33,53 @@ export const Switch = ({
   className = '',
 }: SwitchProps) => {
   const { track, knob } = sizeMap[size];
+  const id = useId();
 
   const trackEl = (
-    <label
-      className={`relative inline-flex items-center ${
+    <span
+      className={`relative inline-flex items-center shrink-0 ${
         disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
-      } ${className}`}
+      }`}
     >
       <input
+        id={id}
         type="checkbox"
         className="sr-only peer"
         checked={checked}
         disabled={disabled}
         onChange={(e) => onChange(e.target.checked)}
       />
-      <div
+      <span
         className={`${track} bg-slate-200 dark:bg-slate-700 peer-focus-visible:ring-2 peer-focus-visible:ring-[#0b57d0]/30 peer-focus-visible:ring-offset-2 rounded-full peer transition-colors after:content-[''] after:absolute after:bg-white after:rounded-full after:shadow-sm after:transition-all peer-checked:after:translate-x-full peer-checked:bg-[#0b57d0] ${knob}`}
       />
-    </label>
+    </span>
   );
 
-  if (!label && !description) return trackEl;
+  if (!label && !description) {
+    return (
+      <label className={`relative inline-flex items-center ${className}`}>
+        {trackEl}
+      </label>
+    );
+  }
 
   return (
-    <div className={`flex items-center gap-3 ${labelPosition === 'right' ? 'flex-row' : 'flex-row-reverse justify-between'}`}>
+    <label
+      htmlFor={id}
+      className={`flex items-center gap-3 cursor-pointer ${
+        disabled ? 'cursor-not-allowed opacity-60' : ''
+      } ${labelPosition === 'right' ? 'flex-row' : 'flex-row-reverse justify-between'} ${className}`}
+    >
       {trackEl}
-      <div className="flex flex-col gap-0.5 select-none">
-        {label && <span className="text-sm font-medium text-slate-900 dark:text-slate-100">{label}</span>}
-        {description && (
-          <span className="text-xs text-slate-500 leading-relaxed">{description}</span>
+      <span className="flex flex-col gap-0.5 select-none min-w-0">
+        {label && (
+          <span className="text-sm font-medium text-[var(--text-primary)]">{label}</span>
         )}
-      </div>
-    </div>
+        {description && (
+          <span className="text-xs text-[var(--text-secondary)] leading-relaxed">{description}</span>
+        )}
+      </span>
+    </label>
   );
 };
 

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -118,7 +118,7 @@ export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       {children}
       {typeof document !== 'undefined' &&
         createPortal(
-          <div className="fixed inset-x-0 bottom-6 z-[300] flex flex-col items-center gap-2 pointer-events-none px-4">
+          <div className="fixed inset-x-0 bottom-28 z-[500] flex flex-col items-center gap-2 pointer-events-none px-4">
             <AnimatePresence initial={false}>
               {toasts.map((toast) => {
                 const Icon = iconMap[toast.variant];

--- a/frontend/src/lib/bodyScrollLock.ts
+++ b/frontend/src/lib/bodyScrollLock.ts
@@ -1,5 +1,14 @@
 let lockCount = 0;
-let previousOverflow = '';
+let previousBodyOverflow = '';
+let previousScrollableOverflow = '';
+let lockedScrollable: HTMLElement | null = null;
+
+function getMainScrollable(): HTMLElement | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  return document.querySelector('.content-scrollable') as HTMLElement | null;
+}
 
 export function lockBodyScroll() {
   if (typeof document === 'undefined') {
@@ -7,8 +16,18 @@ export function lockBodyScroll() {
   }
 
   if (lockCount === 0) {
-    previousOverflow = document.body.style.overflow;
+    previousBodyOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+
+    const scrollable = getMainScrollable();
+    if (scrollable) {
+      lockedScrollable = scrollable;
+      previousScrollableOverflow = scrollable.style.overflow;
+      scrollable.style.overflow = 'hidden';
+    } else {
+      lockedScrollable = null;
+      previousScrollableOverflow = '';
+    }
   }
 
   lockCount += 1;
@@ -26,7 +45,13 @@ export function unlockBodyScroll() {
   lockCount -= 1;
 
   if (lockCount === 0) {
-    document.body.style.overflow = previousOverflow;
-    previousOverflow = '';
+    document.body.style.overflow = previousBodyOverflow;
+    previousBodyOverflow = '';
+
+    if (lockedScrollable) {
+      lockedScrollable.style.overflow = previousScrollableOverflow;
+      lockedScrollable = null;
+      previousScrollableOverflow = '';
+    }
   }
 }

--- a/frontend/src/lib/overlayStack.ts
+++ b/frontend/src/lib/overlayStack.ts
@@ -1,4 +1,4 @@
-type OverlayKind = 'modal' | 'dialog';
+type OverlayKind = 'modal' | 'dialog' | 'drawer';
 
 interface OverlayEntry {
   id: number;
@@ -11,6 +11,13 @@ let nextId = 1;
 const stack: OverlayEntry[] = [];
 let listening = false;
 
+/** Base z-index for stack layers (backdrop = base + index*10, panel = +1) */
+const Z_BASE: Record<OverlayKind, number> = {
+  drawer: 150,
+  modal: 200,
+  dialog: 400,
+};
+
 const handleKeyDown = (event: KeyboardEvent) => {
   const top = stack[stack.length - 1];
   if (!top) {
@@ -19,6 +26,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
 
   if (event.key === 'Escape') {
     event.preventDefault();
+    event.stopPropagation();
     top.onEscape();
     return;
   }
@@ -38,7 +46,8 @@ const ensureListener = () => {
   if (listening || typeof window === 'undefined') {
     return;
   }
-  window.addEventListener('keydown', handleKeyDown);
+  // capture phase so we win over App-level document listeners
+  window.addEventListener('keydown', handleKeyDown, true);
   listening = true;
 };
 
@@ -46,7 +55,7 @@ const maybeRemoveListener = () => {
   if (!listening || stack.length > 0 || typeof window === 'undefined') {
     return;
   }
-  window.removeEventListener('keydown', handleKeyDown);
+  window.removeEventListener('keydown', handleKeyDown, true);
   listening = false;
 };
 
@@ -79,4 +88,20 @@ export function updateOverlay(
   if (patch.onEnter !== undefined) {
     target.onEnter = patch.onEnter;
   }
+}
+
+/** Stack depth of this overlay (0-based among same/all); used for z-index stacking */
+export function getOverlayDepth(id: number): number {
+  return stack.findIndex((item) => item.id === id);
+}
+
+export function getOverlayZIndex(id: number, kind: OverlayKind = 'modal'): { backdrop: number; panel: number } {
+  const depth = Math.max(0, getOverlayDepth(id));
+  // each nested layer +10 so later modals sit above earlier ones
+  const base = Z_BASE[kind] + depth * 10;
+  return { backdrop: base, panel: base + 1 };
+}
+
+export function getStackSize(): number {
+  return stack.length;
 }


### PR DESCRIPTION
## Summary
修全选筛选、数字 NaN、搜索狂请求、创建任务无校验、STRM hover 菜单、AutoSeries 假 UI 等。

> 基于前两个 UI PR 的提交链，请最后合并。

## Changes
- FileManager 全选按可见项；筛选时并集/差集
- Organizer 搜索 300ms debounce
- Settings `parseIntOr` 防 NaN
- CreateTask 必填校验 + 成功 toast + 固定底栏
- AutoSeries 诚实引导，去掉死搜索/假卡片
- STRM 更多菜单 click + 点外关闭
- Switch / Media CAS 整行可点；FolderSelector 失败 toast

## Test plan
- [ ] 文件页筛选后全选只勾可见项，取消全选保留筛外已选
- [ ] 整理器输入搜索不会每键打 API
- [ ] 设置数字框清空再输入不会变 NaN
- [ ] 创建任务空链接会 toast 警告；成功有提示；按钮在底栏固定
- [ ] 手机 STRM 行「⋯」可点开菜单
- [ ] 自动追剧页无假搜索框

## Stack
1. ui/fix-scroll-stack
2. ui/fix-danger-confirm
3. **本 PR** (ui/fix-forms-correctness)