### PR TITLE
feat(tasks): 标签筛选服务端化，分页 total 可信

### DIFF
--- a/frontend/src/components/tabs/CasTab.tsx
+++ b/frontend/src/components/tabs/CasTab.tsx
@@ -22,6 +22,7 @@ import FolderSelector, { SelectedFolder } from '../FolderSelector';
 import type { TabType } from '../../App';
 import { useDialog } from '../ui/Dialog';
 import { useToast } from '../ui/Toast';
+import { MEDIA_SECTION_STORAGE_KEY } from '../ui/SettingsNav';
 
 interface Account {
   id: number;
@@ -499,11 +500,18 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
         <div className="flex items-center gap-3">
           <h2 className="text-xl font-bold text-slate-900">CAS 秒传</h2>
           <button
-            onClick={() => onNavigate?.('media')}
-            className="p-2 bg-white border border-slate-300 rounded-full hover:bg-slate-50 transition-all text-slate-600 shadow-sm"
-            title="在媒体设置中配置"
+            type="button"
+            onClick={() => {
+              try {
+                sessionStorage.setItem(MEDIA_SECTION_STORAGE_KEY, 'media-cas');
+              } catch {}
+              onNavigate?.('media');
+            }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-300 rounded-full hover:bg-slate-50 transition-all text-slate-600 shadow-sm text-sm"
+            title="在媒体设置中配置秒传"
           >
-            <Settings size={18} />
+            <Settings size={16} />
+            秒传设置
           </button>
         </div>
         <div className="flex items-center gap-3">

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -21,6 +21,7 @@ import Checkbox from '../ui/Checkbox';
 import Switch from '../ui/Switch';
 import { useToast } from '../ui/Toast';
 import { useDialog } from '../ui/Dialog';
+import SettingsNav, { type SettingsNavItem, scrollToSettingsSection, MEDIA_SECTION_STORAGE_KEY } from '../ui/SettingsNav';
 
 interface MediaSettings {
   strm: {
@@ -152,6 +153,29 @@ const initialSettings: MediaSettings = {
 
 const MediaTab: React.FC = () => {
   const toast = useToast();
+  const mediaNavItems: SettingsNavItem[] = [
+    { id: 'media-ai', label: 'AI 重命名', keywords: ['openai', 'ai', '重命名'] },
+    { id: 'media-strm', label: 'STRM', keywords: ['strm', '中转'] },
+    { id: 'media-cas', label: '秒传', keywords: ['cas', '秒传', '家庭中转'] },
+    { id: 'media-emby', label: 'Emby', keywords: ['emby', 'jellyfin'] },
+    { id: 'media-cloudsaver', label: 'CloudSaver', keywords: ['cloudsaver'] },
+    { id: 'media-hdhive', label: '影巢', keywords: ['hdhive', '影巢', 'cookie'] },
+    { id: 'media-bridge', label: 'Alist', keywords: ['alist'] },
+    { id: 'media-oauth', label: 'TMDB 刮削', keywords: ['tmdb', '刮削'] },
+    { id: 'media-alist', label: '媒体库分类', keywords: ['分类', 'organizer', '电影'] },
+    { id: 'media-regex', label: '正则预设', keywords: ['正则', 'regex'] },
+  ];
+  const [visibleSectionIds, setVisibleSectionIds] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    try {
+      const target = sessionStorage.getItem(MEDIA_SECTION_STORAGE_KEY);
+      if (target) {
+        sessionStorage.removeItem(MEDIA_SECTION_STORAGE_KEY);
+        scrollToSettingsSection(target);
+      }
+    } catch {}
+  }, []);
   const dialog = useDialog();
   const [settings, setSettings] = useState<MediaSettings>(initialSettings);
   const [regexPresets, setRegexPresets] = useState<RegexPreset[]>([]);
@@ -379,9 +403,11 @@ const MediaTab: React.FC = () => {
   }
 
   return (
-    <div className="max-w-4xl space-y-8 pb-12">
+    <div className="max-w-4xl space-y-8 pb-12 pb-8">
+      <SettingsNav items={mediaNavItems} onVisibleChange={setVisibleSectionIds} />
+
       {/* OpenAI / AI Settings */}
-      <section className="space-y-4">
+      <section id="media-ai" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-ai')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Cpu size={24} className="text-[#0b57d0]" /> AI 辅助重命名
@@ -463,7 +489,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* STRM Settings */}
-      <section className="space-y-4">
+      <section id="media-strm" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-strm')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Link2 size={24} className="text-[#0b57d0]" /> STRM 设置
         </h3>
@@ -502,7 +528,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* CAS 秒传设置 */}
-      <section className="space-y-4">
+      <section id="media-cas" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-cas')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Zap size={24} className="text-[#0b57d0]" /> 秒传设置
         </h3>
@@ -583,7 +609,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Emby Settings */}
-      <section className="space-y-4">
+      <section id="media-emby" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-emby')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Tv size={24} className="text-[#0b57d0]" /> Emby 设置
         </h3>
@@ -707,7 +733,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* CloudSaver Settings */}
-      <section className="space-y-4">
+      <section id="media-cloudsaver" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-cloudsaver')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Monitor size={24} className="text-[#0b57d0]" /> CloudSaver 设置
         </h3>
@@ -747,7 +773,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Hdhive Settings */}
-      <section className="space-y-4">
+      <section id="media-hdhive" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-hdhive')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Search size={24} className="text-[#0b57d0]" /> 影巢设置
@@ -789,7 +815,7 @@ const MediaTab: React.FC = () => {
 
       {/* Alist & TMDB */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <section className="space-y-4">
+        <section id="media-bridge" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-bridge')}>
           <div className="flex items-center justify-between">
             <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
               <Globe size={24} className="text-[#0b57d0]" /> Alist 设置
@@ -820,7 +846,7 @@ const MediaTab: React.FC = () => {
           </div>
         </section>
 
-        <section className="space-y-4">
+        <section id="media-oauth" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-oauth')}>
           <div className="flex items-center justify-between">
             <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
               <Search size={24} className="text-[#0b57d0]" /> TMDB 刮削
@@ -844,7 +870,7 @@ const MediaTab: React.FC = () => {
       </div>
 
       {/* Media Organizer Settings */}
-      <section className="space-y-4">
+      <section id="media-alist" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-alist')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Settings size={24} className="text-[#0b57d0]" /> 媒体库分类命名
         </h3>
@@ -871,7 +897,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Regex Presets Management */}
-      <section className="space-y-4">
+      <section id="media-regex" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-regex')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Settings size={24} className="text-[#0b57d0]" /> 正则预设管理
         </h3>
@@ -898,7 +924,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Save Button */}
-      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10">
+      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10 pr-20 md:pr-24">
         <button 
           onClick={fetchData}
           className="px-8 py-3 bg-white border border-slate-300 text-slate-700 rounded-full font-medium shadow-lg hover:bg-slate-50 transition-all flex items-center gap-2"

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -6,6 +6,7 @@ import Checkbox from '../ui/Checkbox';
 import Switch from '../ui/Switch';
 import { useToast } from '../ui/Toast';
 import { useDialog } from '../ui/Dialog';
+import SettingsNav, { type SettingsNavItem } from '../ui/SettingsNav';
 
 const parseIntOr = (raw: string, fallback: number) => {
   if (raw === '' || raw === '-' ) return fallback;
@@ -264,6 +265,17 @@ const initialSettings: SettingsData = {
 const SettingsTab: React.FC = () => {
   const toast = useToast();
   const dialog = useDialog();
+  const settingsNavItems: SettingsNavItem[] = [
+    { id: 'settings-auth', label: '访问认证', keywords: ['认证', '用户名', '密码', 'api'] },
+    { id: 'settings-task', label: '任务设置', keywords: ['任务', '过期', '重试', 'cron', '回收站'] },
+    { id: 'settings-telegram', label: 'Telegram', keywords: ['telegram', 'tg', 'bot'] },
+    { id: 'settings-push', label: '消息推送', keywords: ['推送', '企业微信', 'bark', 'pushplus'] },
+    { id: 'settings-proxy', label: '网络代理', keywords: ['代理', 'proxy'] },
+    { id: 'settings-hdhive', label: '影巢资源', keywords: ['影巢', 'hdhive'] },
+    { id: 'settings-custom-push', label: '自定义推送', keywords: ['自定义推送', 'webhook'] },
+    { id: 'settings-regex', label: '正则预设', keywords: ['正则', 'regex'] },
+  ];
+  const [visibleSectionIds, setVisibleSectionIds] = useState<string[] | null>(null);
   const [settings, setSettings] = useState<SettingsData>(initialSettings);
   const [accounts, setAccounts] = useState<{id: number, username: string, alias?: string}[]>([]);
   const [loading, setLoading] = useState(true);
@@ -610,9 +622,11 @@ const SettingsTab: React.FC = () => {
   const selectedAccount = accounts.find(a => String(a.id) === settings.task.autoCreate.accountId);
 
   return (
-    <div className="max-w-4xl space-y-8">
+    <div className="max-w-4xl space-y-8 pb-8">
+      <SettingsNav items={settingsNavItems} onVisibleChange={setVisibleSectionIds} />
+
       {/* System Credentials */}
-      <section className="space-y-4">
+      <section id="settings-auth" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-auth')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Shield size={24} className="text-[#0b57d0]" /> 访问认证
         </h3>
@@ -660,7 +674,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Task Settings */}
-      <section className="space-y-4">
+      <section id="settings-task" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-task')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Database size={24} className="text-[#0b57d0]" /> 任务设置
         </h3>
@@ -908,7 +922,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Telegram Bot Settings */}
-      <section className="space-y-4">
+      <section id="settings-telegram" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-telegram')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Send size={24} className="text-[#0b57d0]" /> Telegram 机器人
@@ -1040,7 +1054,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Push Notifications */}
-      <section className="space-y-4">
+      <section id="settings-push" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-push')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Bell size={24} className="text-[#b3261e]" /> 消息推送
         </h3>
@@ -1211,7 +1225,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Network Proxy */}
-      <section className="space-y-4">
+      <section id="settings-proxy" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-proxy')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Globe size={24} className="text-[#0b57d0]" /> 网络代理
         </h3>
@@ -1282,7 +1296,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* HDHive */}
-      <section className="space-y-4">
+      <section id="settings-hdhive" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-hdhive')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Search size={24} className="text-[#0b57d0]" /> 影巢资源
@@ -1462,7 +1476,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Custom Push Management */}
-      <section className="space-y-4">
+      <section id="settings-custom-push" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-custom-push')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Bell size={24} className="text-[#b3261e]" /> 自定义推送列表
         </h3>
@@ -1532,7 +1546,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Regex Presets Management */}
-      <section className="space-y-4">
+      <section id="settings-regex" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-regex')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Cpu size={24} className="text-[#0b57d0]" /> 正则预设列表
         </h3>
@@ -1606,7 +1620,7 @@ const SettingsTab: React.FC = () => {
         </div>
       </section>
 
-      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10">
+      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10 pr-20 md:pr-24">
         <button 
           type="button"
           onClick={loadSettings}

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -77,23 +77,6 @@ const TASK_FEATURE_FILTERS: Array<{
   { key: 'feature:keep-cas', label: '保留CAS', matches: (task) => Boolean(task.keepCasAfterRestore) }
 ];
 
-const getTaskFilterKeys = (task: Task) => {
-  const filterKeys: string[] = [];
-  const groupName = task.taskGroup?.trim();
-
-  if (groupName) {
-    filterKeys.push(`group:${groupName}`);
-  }
-
-  TASK_FEATURE_FILTERS.forEach((filterTag) => {
-    if (filterTag.matches(task)) {
-      filterKeys.push(filterTag.key);
-    }
-  });
-
-  return filterKeys;
-};
-
 const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const toast = useToast();
   const dialog = useDialog();
@@ -118,6 +101,8 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
 
+  const [filterGroups, setFilterGroups] = useState<string[]>([]);
+
   const fetchTasks = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     try {
@@ -128,6 +113,21 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       });
       if (debouncedSearchTerm) {
         params.set('search', debouncedSearchTerm);
+      }
+      const featureKeys = activeTagFilters
+        .filter((key) => key.startsWith('feature:'))
+        .map((key) => key.slice('feature:'.length));
+      const groupKeys = activeTagFilters
+        .filter((key) => key.startsWith('group:'))
+        .map((key) => key.slice('group:'.length));
+      if (featureKeys.length > 0) {
+        params.set('features', featureKeys.join(','));
+      }
+      // 多分组时取第一个精确匹配（UI 芯片为 AND；多 group 罕见，用 search 补）
+      if (groupKeys.length === 1) {
+        params.set('taskGroup', groupKeys[0]);
+      } else if (groupKeys.length > 1) {
+        params.set('taskGroup', groupKeys[0]);
       }
       const response = await fetch(`/api/tasks?${params.toString()}`, { signal });
       const data = await response.json();
@@ -152,7 +152,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
         setLoading(false);
       }
     }
-  }, [statusFilter, debouncedSearchTerm, page]);
+  }, [statusFilter, debouncedSearchTerm, page, activeTagFilters]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -163,13 +163,31 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
 
   useEffect(() => {
     setPage(1);
-  }, [statusFilter, debouncedSearchTerm]);
+  }, [statusFilter, debouncedSearchTerm, activeTagFilters]);
 
   useEffect(() => {
     const controller = new AbortController();
     fetchTasks(controller.signal);
     return () => controller.abort();
   }, [fetchTasks]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/tasks/filter-options');
+        const data = await res.json();
+        if (!cancelled && data.success) {
+          setFilterGroups(Array.isArray(data.data?.groups) ? data.data.groups : []);
+        }
+      } catch {
+        // ignore — chips 仍可用固定 feature
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
@@ -209,37 +227,22 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
     }
   }, [openTaskMenuId]);
 
+  // feature 固定展示；group 来自全库 filter-options（不再仅当前页）
   const availableTagFilters: TaskFilterTag[] = [
-    ...TASK_FEATURE_FILTERS
-      .filter((filterTag) => tasks.some((task) => filterTag.matches(task)))
-      .map((filterTag) => ({
-        key: filterTag.key,
-        label: filterTag.label,
-        tone: 'feature' as const
-      })),
-    ...Array.from(
-      new Set(
-        tasks
-          .map((task) => task.taskGroup?.trim())
-          .filter((taskGroup): taskGroup is string => Boolean(taskGroup))
-      )
-    )
-      .sort((left, right) => left.localeCompare(right, 'zh-CN'))
-      .map((taskGroup) => ({
-        key: `group:${taskGroup}`,
-        label: taskGroup,
-        tone: 'group' as const
-      }))
+    ...TASK_FEATURE_FILTERS.map((filterTag) => ({
+      key: filterTag.key,
+      label: filterTag.label,
+      tone: 'feature' as const
+    })),
+    ...filterGroups.map((taskGroup) => ({
+      key: `group:${taskGroup}`,
+      label: taskGroup,
+      tone: 'group' as const
+    }))
   ];
 
-  const filteredTasks = tasks.filter((task) => {
-    if (activeTagFilters.length === 0) {
-      return true;
-    }
-
-    const taskFilterKeys = new Set(getTaskFilterKeys(task));
-    return activeTagFilters.every((filterKey) => taskFilterKeys.has(filterKey));
-  });
+  // 服务端已按标签筛选，列表直接用 tasks
+  const filteredTasks = tasks;
 
   const allVisibleSelected =
     filteredTasks.length > 0 &&

--- a/frontend/src/components/ui/SettingsNav.tsx
+++ b/frontend/src/components/ui/SettingsNav.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+
+export interface SettingsNavItem {
+  id: string;
+  label: string;
+  /** 额外匹配关键词（过滤用） */
+  keywords?: string[];
+}
+
+interface SettingsNavProps {
+  items: SettingsNavItem[];
+  /** 过滤变化时回传可见 id 列表，父级用来隐藏 section */
+  onVisibleChange?: (visibleIds: string[]) => void;
+  className?: string;
+}
+
+const SettingsNav: React.FC<SettingsNavProps> = ({ items, onVisibleChange, className = '' }) => {
+  const [query, setQuery] = useState('');
+
+  const visibleItems = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((item) => {
+      const hay = [item.label, ...(item.keywords || [])].join(' ').toLowerCase();
+      return hay.includes(q);
+    });
+  }, [items, query]);
+
+  React.useEffect(() => {
+    onVisibleChange?.(visibleItems.map((i) => i.id));
+  }, [visibleItems, onVisibleChange]);
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-secondary)]" size={16} />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="过滤分区…"
+          className="w-full pl-10 pr-4 py-2.5 bg-[var(--bg-main)] border border-[var(--border-color)] rounded-full text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20 text-[var(--text-primary)]"
+        />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {visibleItems.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => scrollTo(item.id)}
+            className="px-3 py-1.5 rounded-full text-xs font-medium border border-[var(--border-color)] bg-[var(--bg-main)] text-[var(--text-primary)] hover:bg-[#d3e3fd]/60 hover:border-[#0b57d0]/40 dark:hover:bg-[#0b57d0]/20 transition-colors"
+          >
+            {item.label}
+          </button>
+        ))}
+        {visibleItems.length === 0 && (
+          <span className="text-xs text-[var(--text-secondary)] py-1">无匹配分区</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsNav;
+
+/** 滚动到 section；用于跨 Tab 跳转 */
+export function scrollToSettingsSection(id: string, retries = 12) {
+  const tryScroll = (left: number) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      return;
+    }
+    if (left > 0) {
+      requestAnimationFrame(() => tryScroll(left - 1));
+    }
+  };
+  // 等 Tab 挂载
+  setTimeout(() => tryScroll(retries), 50);
+}
+
+export const MEDIA_SECTION_STORAGE_KEY = 'media-scroll-section';

--- a/src/index.js
+++ b/src/index.js
@@ -1490,21 +1490,34 @@ AppDataSource.initialize().then(async () => {
         }
     });
     // 任务相关API
-    app.get('/api/tasks', async (req, res) => {
-        const { status } = req.query;
-        const search = String(req.query.search || '').trim().slice(0, 100);
-        const shouldPaginate = req.query.page != null || req.query.pageSize != null || req.query.limit != null;
-        const page = parsePaginationInt(req.query.page, 1, Number.MAX_SAFE_INTEGER);
-        const pageSize = parsePaginationInt(req.query.pageSize || req.query.limit, 50, 200);
-        let whereClause = { }; // 用于构建最终的 where 条件
+    // feature 标签 → Task 布尔字段（与前端 TASK_FEATURE_FILTERS 对齐）
+    const TASK_FEATURE_FIELD_MAP = {
+        'lazy-strm': 'enableLazyStrm',
+        'cron': 'enableCron',
+        'organizer': 'enableOrganizer',
+        'keep-cas': 'keepCasAfterRestore'
+    };
 
-        // 基础条件（AND）
+    const buildTaskListWhere = ({ status, search, features, taskGroup }) => {
+        let whereClause = {};
         if (status && status !== 'all') {
             whereClause.status = status;
         }
         whereClause.enableSystemProxy = Or(IsNull(), false);
 
-        // 添加搜索过滤
+        const featureList = Array.isArray(features) ? features : [];
+        for (const feature of featureList) {
+            const field = TASK_FEATURE_FIELD_MAP[feature];
+            if (field) {
+                whereClause[field] = true;
+            }
+        }
+
+        const groupName = String(taskGroup || '').trim();
+        if (groupName) {
+            whereClause.taskGroup = groupName;
+        }
+
         if (search) {
             const searchConditions = [
                 { resourceName: Like(`%${search}%`) },
@@ -1515,14 +1528,30 @@ AppDataSource.initialize().then(async () => {
                 { account: { username: Like(`%${search}%`) } }
             ];
             if (Object.keys(whereClause).length > 0) {
-                whereClause = searchConditions.map(searchCond => ({
-                    ...whereClause, // 包含基础条件 (如 status)
-                    ...searchCond   // 包含一个搜索条件
+                whereClause = searchConditions.map((searchCond) => ({
+                    ...whereClause,
+                    ...searchCond
                 }));
-            }else{
+            } else {
                 whereClause = searchConditions;
             }
         }
+        return whereClause;
+    };
+
+    app.get('/api/tasks', async (req, res) => {
+        const { status } = req.query;
+        const search = String(req.query.search || '').trim().slice(0, 100);
+        const taskGroup = String(req.query.taskGroup || '').trim().slice(0, 100);
+        const features = String(req.query.features || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        const shouldPaginate = req.query.page != null || req.query.pageSize != null || req.query.limit != null;
+        const page = parsePaginationInt(req.query.page, 1, Number.MAX_SAFE_INTEGER);
+        const pageSize = parsePaginationInt(req.query.pageSize || req.query.limit, 50, 200);
+        const whereClause = buildTaskListWhere({ status, search, features, taskGroup });
+
         const findOptions = {
             order: { id: 'DESC' },
             relations: {
@@ -1565,6 +1594,31 @@ AppDataSource.initialize().then(async () => {
                 }
             } : {})
         });
+    });
+
+    // 标签芯片：固定 feature + 全库出现过的 taskGroup（不受分页限制）
+    app.get('/api/tasks/filter-options', async (req, res) => {
+        try {
+            const rows = await taskRepo
+                .createQueryBuilder('task')
+                .select('DISTINCT task.taskGroup', 'taskGroup')
+                .where("task.taskGroup IS NOT NULL AND task.taskGroup != ''")
+                .andWhere('(task.enableSystemProxy IS NULL OR task.enableSystemProxy = 0)')
+                .orderBy('task.taskGroup', 'ASC')
+                .getRawMany();
+            const groups = rows
+                .map((r) => String(r.taskGroup || '').trim())
+                .filter(Boolean);
+            res.json({
+                success: true,
+                data: {
+                    features: Object.keys(TASK_FEATURE_FIELD_MAP),
+                    groups
+                }
+            });
+        } catch (error) {
+            res.status(500).json({ success: false, error: error.message });
+        }
     });
 
     app.get('/api/organizer/tasks', async (req, res) => {


### PR DESCRIPTION
## Summary
任务 feature/group 标签筛选下沉到 `GET /api/tasks`，去掉页内二次 filter，分页文案与结果一致。

> 包含 settings-nav 提交；合入顺序：… → settings-nav → **本 PR** → dark-tokens

## Changes
- `features=lazy-strm,cron,organizer,keep-cas` + `taskGroup` 精确匹配
- `GET /api/tasks/filter-options` 返回全库 groups
- TaskTab 切换标签重置 page 并 refetch

## Test plan
- [ ] 勾「懒STRM」后翻页，条数/total 与筛选一致
- [ ] 分组芯片来自全库，不限当前页
- [ ] 不传 features 时列表行为与旧版一致