### PR TITLE
feat(ui): 设置导航 / 任务标签服务端筛选 / 暗色 token + 交互修复

### DIFF
--- a/frontend/src/components/tabs/AccountTab.tsx
+++ b/frontend/src/components/tabs/AccountTab.tsx
@@ -471,7 +471,7 @@ const AccountTab: React.FC = () => {
 
       {storageSummary && storageSummary.enabled && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="bg-white rounded-3xl border border-slate-200/60 p-6 shadow-sm">
+          <div className="ui-card p-6 shadow-sm">
             <div className="flex items-center gap-3 mb-4">
               <Database size={20} className="text-[#0b57d0]" />
               <span className="text-sm font-semibold text-slate-900">个人容量聚合</span>
@@ -479,7 +479,7 @@ const AccountTab: React.FC = () => {
             <div className="flex items-end justify-between">
               <div>
                 <p className="text-2xl font-semibold text-slate-900">{formatBytes(storageSummary.cloud.used)}</p>
-                <p className="text-xs text-slate-500 mt-1">总容量 {formatBytes(storageSummary.cloud.total)}</p>
+                <p className="text-xs ui-muted mt-1">总容量 {formatBytes(storageSummary.cloud.total)}</p>
               </div>
               <span className="text-xs text-slate-400">{storageSummary.accounts.length} 个账号</span>
             </div>
@@ -487,7 +487,7 @@ const AccountTab: React.FC = () => {
               <div className="h-full bg-[#0b57d0]" style={{ width: `${storageSummary.cloud.total ? Math.min(100, storageSummary.cloud.used / storageSummary.cloud.total * 100) : 0}%` }} />
             </div>
           </div>
-          <div className="bg-white rounded-3xl border border-slate-200/60 p-6 shadow-sm">
+          <div className="ui-card p-6 shadow-sm">
             <div className="flex items-center gap-3 mb-4">
               <Database size={20} className="text-slate-500" />
               <span className="text-sm font-semibold text-slate-900">家庭容量聚合</span>
@@ -495,7 +495,7 @@ const AccountTab: React.FC = () => {
             <div className="flex items-end justify-between">
               <div>
                 <p className="text-2xl font-semibold text-slate-900">{formatBytes(storageSummary.family.used)}</p>
-                <p className="text-xs text-slate-500 mt-1">总容量 {formatBytes(storageSummary.family.total)}</p>
+                <p className="text-xs ui-muted mt-1">总容量 {formatBytes(storageSummary.family.total)}</p>
               </div>
               <span className="text-xs text-slate-400">含家庭空间</span>
             </div>
@@ -506,7 +506,7 @@ const AccountTab: React.FC = () => {
         </div>
       )}
       
-      <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+      <div className="ui-card overflow-hidden shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50/50 border-b border-slate-100">
@@ -584,8 +584,8 @@ const AccountTab: React.FC = () => {
                         {(account.username || 'U').substring(0, 3)}
                       </div>
                       <div className="flex flex-col">
-                        <span className="font-medium text-slate-900">{account.username || '未知'}</span>
-                        <span className="text-xs text-slate-500">
+                        <span className="font-medium ui-title">{account.username || '未知'}</span>
+                        <span className="text-xs ui-muted">
                           {account.accountType === 'family' ? '家庭云' : '个人云'}
                           {account.familyId && ` / ${account.familyId}`}
                         </span>
@@ -602,7 +602,7 @@ const AccountTab: React.FC = () => {
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex flex-col gap-1.5">
-                      <div className="flex justify-between text-xs text-slate-500">
+                      <div className="flex justify-between text-xs ui-muted">
                         <span>{formatBytes(cloudUsed)}</span>
                         <span>{formatBytes(cloudTotal)}</span>
                       </div>
@@ -624,7 +624,7 @@ const AccountTab: React.FC = () => {
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex flex-col gap-1.5">
-                      <div className="flex justify-between text-xs text-slate-500">
+                      <div className="flex justify-between text-xs ui-muted">
                         <span>{formatBytes(familyUsed)}</span>
                         <span>{formatBytes(familyTotal)}</span>
                       </div>
@@ -672,7 +672,7 @@ const AccountTab: React.FC = () => {
         <form id="modal-form" onSubmit={handleSubmit} className="space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">用户名</label>
+              <label className="text-sm font-medium ui-title">用户名</label>
               <input 
                 type="text" 
                 value={formData.username}
@@ -683,7 +683,7 @@ const AccountTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">密码</label>
+              <label className="text-sm font-medium ui-title">密码</label>
               <input
                 type="password"
                 value={formData.password}
@@ -694,7 +694,7 @@ const AccountTab: React.FC = () => {
             </div>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">Cookie (可选)</label>
+            <label className="text-sm font-medium ui-title">Cookie (可选)</label>
             <textarea
               rows={3}
               value={formData.cookies}
@@ -702,7 +702,7 @@ const AccountTab: React.FC = () => {
               placeholder={editingAccount?.hasCookies ? '已保存 Cookie；留空不覆盖' : '可选 Cookie'}
               className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
             />
-            <p className="text-xs text-slate-500">
+            <p className="text-xs ui-muted">
               {editingAccount
                 ? '编辑时密码/Cookie 留空表示不修改；若都填写则优先使用密码。'
                 : '密码和 Cookie 至少填写一个，如果都填写，则只有账号密码生效。'}
@@ -710,7 +710,7 @@ const AccountTab: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">别名</label>
+              <label className="text-sm font-medium ui-title">别名</label>
               <input 
                 type="text" 
                 value={formData.alias}
@@ -719,7 +719,7 @@ const AccountTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">账号类型</label>
+              <label className="text-sm font-medium ui-title">账号类型</label>
               <select 
                 value={formData.accountType}
                 onChange={e => setFormData({...formData, accountType: e.target.value as 'personal' | 'family'})}
@@ -733,7 +733,7 @@ const AccountTab: React.FC = () => {
           {formData.accountType === 'family' && (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-700">Family ID</label>
+                <label className="text-sm font-medium ui-title">Family ID</label>
                 <input
                   type="text"
                   value={formData.familyId}
@@ -742,7 +742,7 @@ const AccountTab: React.FC = () => {
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-700">家庭中转目录ID</label>
+                <label className="text-sm font-medium ui-title">家庭中转目录ID</label>
                 <input
                   type="text"
                   value={formData.familyFolderId}
@@ -796,13 +796,13 @@ const AccountTab: React.FC = () => {
           {qrData?.qrUrl ? (
             <img src={qrData.qrUrl} alt="天翼云盘登录二维码" className="h-56 w-56 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm" />
           ) : (
-            <div className="flex h-56 w-56 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-slate-50 text-sm text-slate-500">
+            <div className="flex h-56 w-56 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-slate-50 text-sm ui-muted">
               获取二维码中...
             </div>
           )}
           <div className="text-center">
-            <p className="text-sm font-medium text-slate-900">{qrMessage}</p>
-            <p className="mt-1 text-xs text-slate-500">使用天翼云盘 App 扫码并确认后会自动添加或更新账号。</p>
+            <p className="text-sm font-medium ui-title">{qrMessage}</p>
+            <p className="mt-1 text-xs ui-muted">使用天翼云盘 App 扫码并确认后会自动添加或更新账号。</p>
           </div>
         </div>
       </Modal>

--- a/frontend/src/components/tabs/CasTab.tsx
+++ b/frontend/src/components/tabs/CasTab.tsx
@@ -498,7 +498,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       {/* 标题栏 */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div className="flex items-center gap-3">
-          <h2 className="text-xl font-bold text-slate-900">CAS 秒传</h2>
+          <h2 className="text-xl font-bold ui-title">CAS 秒传</h2>
           <button
             type="button"
             onClick={() => {
@@ -515,7 +515,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
           </button>
         </div>
         <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2 text-sm text-slate-500">
+          <div className="flex items-center gap-2 text-sm ui-muted">
             {config.enableFamilyTransit ? (
               <span className="flex items-center gap-1 text-emerald-600">
                 <CheckCircle2 size={14} /> 家庭中转已启用
@@ -531,18 +531,18 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
 
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         {/* 粘贴恢复 */}
-        <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+        <div className="ui-card overflow-hidden shadow-sm">
           <div className="p-6 border-b border-slate-100">
             <div className="flex items-center gap-2">
               <Download className="text-blue-500" size={20} />
-              <h3 className="font-bold text-slate-900">秒传恢复</h3>
+              <h3 className="font-bold ui-title">秒传恢复</h3>
             </div>
-            <p className="text-sm text-slate-500 mt-1">粘贴单个 .cas 存根内容，立即恢复到网盘</p>
+            <p className="text-sm ui-muted mt-1">粘贴单个 .cas 存根内容，立即恢复到网盘</p>
           </div>
 
           <div className="p-6 space-y-4">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">执行账号</label>
+              <label className="block text-sm font-medium ui-title mb-2">执行账号</label>
               <select
                 value={selectedAccountId || ''}
                 onChange={(e) => setSelectedAccountId(Number(e.target.value))}
@@ -555,7 +555,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">存根内容 (Base64 或 JSON)</label>
+              <label className="block text-sm font-medium ui-title mb-2">存根内容 (Base64 或 JSON)</label>
               <textarea
                 value={casContent}
                 onChange={(e) => setCasContent(e.target.value)}
@@ -565,7 +565,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">自定义文件名 (可选)</label>
+              <label className="block text-sm font-medium ui-title mb-2">自定义文件名 (可选)</label>
               <input
                 type="text"
                 value={restoreName}
@@ -576,7 +576,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">存入目录</label>
+              <label className="block text-sm font-medium ui-title mb-2">存入目录</label>
               <button
                 onClick={() => openFolderSelector('restore')}
                 className="w-full flex items-center justify-between px-4 py-2.5 bg-white border border-slate-300 rounded-xl text-sm hover:border-[#0b57d0] transition-all"
@@ -600,18 +600,18 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
         </div>
 
         {/* 存根导入 */}
-        <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+        <div className="ui-card overflow-hidden shadow-sm">
           <div className="p-6 border-b border-slate-100">
             <div className="flex items-center gap-2">
               <Upload className="text-violet-500" size={20} />
-              <h3 className="font-bold text-slate-900">存根导入</h3>
+              <h3 className="font-bold ui-title">存根导入</h3>
             </div>
-            <p className="text-sm text-slate-500 mt-1">上传 .cas / zip / rar 包（含 .cas 目录树），批量秒传并生成 STRM</p>
+            <p className="text-sm ui-muted mt-1">上传 .cas / zip / rar 包（含 .cas 目录树），批量秒传并生成 STRM</p>
           </div>
 
           <div className="p-6 space-y-4">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">选择文件</label>
+              <label className="block text-sm font-medium ui-title mb-2">选择文件</label>
               {/* 不限制 accept：部分浏览器对未知 MIME 的 .cas 会整项灰掉，无法点选 */}
               <input
                 ref={fileInputRef}
@@ -644,7 +644,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                   </div>
                   <div className="min-w-0">
                     <div className="text-sm font-medium text-slate-800">点击选择 .cas / .zip / .rar</div>
-                    <div className="text-xs text-slate-500 mt-0.5">支持单个存根或含 .cas 的压缩包</div>
+                    <div className="text-xs ui-muted mt-0.5">支持单个存根或含 .cas 的压缩包</div>
                   </div>
                 </button>
               ) : (
@@ -657,10 +657,10 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                     )}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-slate-900 truncate" title={selectedFile.name}>
+                    <div className="text-sm font-medium ui-title truncate" title={selectedFile.name}>
                       {selectedFile.name}
                     </div>
-                    <div className="text-xs text-slate-500 mt-0.5">
+                    <div className="text-xs ui-muted mt-0.5">
                       {(selectedFile.size / 1024).toFixed(1)} KB
                     </div>
                   </div>
@@ -689,7 +689,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">任务标题（可选）</label>
+              <label className="block text-sm font-medium ui-title mb-2">任务标题（可选）</label>
               <input
                 type="text"
                 value={importTitle}
@@ -700,7 +700,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">存入目录</label>
+              <label className="block text-sm font-medium ui-title mb-2">存入目录</label>
               <button
                 onClick={() => openFolderSelector('import')}
                 className="w-full flex items-center justify-between px-4 py-2.5 bg-white border border-slate-300 rounded-xl text-sm hover:border-[#0b57d0] transition-all"
@@ -714,7 +714,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
 
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">还原模式</label>
+                <label className="block text-sm font-medium ui-title mb-2">还原模式</label>
                 <select
                   value={importMode}
                   onChange={(e) => setImportMode(e.target.value as 'restore' | 'lazy')}
@@ -725,7 +725,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">目录整理</label>
+                <label className="block text-sm font-medium ui-title mb-2">目录整理</label>
                 <select
                   value={organizeMode}
                   onChange={(e) => setOrganizeMode(e.target.value as 'library' | 'mirror')}
@@ -736,7 +736,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">STRM</label>
+                <label className="block text-sm font-medium ui-title mb-2">STRM</label>
                 <select
                   value={importStrmMode}
                   onChange={(e) => setImportStrmMode(e.target.value as 'none' | 'normal' | 'lazy')}
@@ -760,7 +760,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
               </label>
             </div>
 
-            <div className="rounded-2xl bg-slate-50 border border-slate-100 px-4 py-3 text-xs text-slate-500 space-y-1">
+            <div className="rounded-2xl bg-slate-50 border border-slate-100 px-4 py-3 text-xs ui-muted space-y-1">
               <p>账号：{selectedAccountLabel || '未选择'}</p>
               <p>
                 {organizeMode === 'library'
@@ -783,11 +783,11 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
       </div>
 
       {/* 导入任务 */}
-      <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+      <div className="ui-card overflow-hidden shadow-sm">
         <div className="p-6 border-b border-slate-100 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <List className="text-slate-700" size={20} />
-            <h3 className="font-bold text-slate-900">导入任务</h3>
+            <h3 className="font-bold ui-title">导入任务</h3>
           </div>
           <button
             onClick={() => { fetchJobs(); if (activeJobId) fetchJobDetail(activeJobId); }}
@@ -815,7 +815,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
                           {job.mode === 'lazy' ? '懒还原' : '立即还原'} / STRM:{job.strmMode}
                         </span>
                       </div>
-                      <p className="text-xs text-slate-500 truncate">
+                      <p className="text-xs ui-muted truncate">
                         源：{job.sourceName} · 成功 {job.success}/{job.total} · 失败 {job.failed} · 跳过 {job.skipped}
                       </p>
                       {job.message && <p className="text-xs text-slate-400">{job.message}</p>}
@@ -852,9 +852,9 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
               <div className="flex items-center justify-between mb-3">
                 <h4 className="font-semibold text-slate-800">任务详情：{activeJob.title}</h4>
-                <button onClick={() => { setActiveJob(null); setActiveJobId(null); }} className="text-xs text-slate-500">关闭</button>
+                <button onClick={() => { setActiveJob(null); setActiveJobId(null); }} className="text-xs ui-muted">关闭</button>
               </div>
-              <p className="text-xs text-slate-500 mb-3">
+              <p className="text-xs ui-muted mb-3">
                 {statusLabel(activeJob.status)} · 成功 {activeJob.success} / 失败 {activeJob.failed} / 跳过 {activeJob.skipped} / 共 {activeJob.total}
               </p>
               {failedEntries.length > 0 ? (
@@ -879,11 +879,11 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
 
       {/* 管理区 */}
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-        <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+        <div className="ui-card overflow-hidden shadow-sm">
           <div className="p-6 border-b border-slate-100 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <FolderArchive className="text-sky-500" size={20} />
-              <h3 className="font-bold text-slate-900">导入 STRM</h3>
+              <h3 className="font-bold ui-title">导入 STRM</h3>
             </div>
             <button
               onClick={() => fetchStrmList(strmPath)}
@@ -893,7 +893,7 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             </button>
           </div>
           <div className="p-6 space-y-3">
-            <div className="flex items-center gap-2 text-xs text-slate-500">
+            <div className="flex items-center gap-2 text-xs ui-muted">
               <span>当前路径：</span>
               <code className="bg-slate-50 border border-slate-200 px-2 py-1 rounded-lg">{strmPath || '(根/CAS导入)'}</code>
               {!!strmPath && (
@@ -946,11 +946,11 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
           </div>
         </div>
 
-        <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+        <div className="ui-card overflow-hidden shadow-sm">
           <div className="p-6 border-b border-slate-100 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <AlertCircle className="text-amber-500" size={20} />
-              <h3 className="font-bold text-slate-900">分享懒 STRM 缓存</h3>
+              <h3 className="font-bold ui-title">分享懒 STRM 缓存</h3>
             </div>
             <div className="flex items-center gap-2">
               <button
@@ -1012,10 +1012,10 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
             <p>Hash 命中即可恢复，无需上传原片；未命中会失败。</p>
           </div>
         </div>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-6">
+        <div className="ui-card p-6">
           <div className="flex items-center gap-2 mb-3">
             <Zap className="text-amber-500" size={18} />
-            <h3 className="font-bold text-slate-900">导入包说明</h3>
+            <h3 className="font-bold ui-title">导入包说明</h3>
           </div>
           <div className="space-y-2 text-sm text-slate-600">
             <p>支持单个 `.cas`，或 zip / rar 内整树 `.cas`（如剧集 Season 目录）。</p>

--- a/frontend/src/components/tabs/CasTab.tsx
+++ b/frontend/src/components/tabs/CasTab.tsx
@@ -22,6 +22,7 @@ import FolderSelector, { SelectedFolder } from '../FolderSelector';
 import type { TabType } from '../../App';
 import { useDialog } from '../ui/Dialog';
 import { useToast } from '../ui/Toast';
+import { MEDIA_SECTION_STORAGE_KEY } from '../ui/SettingsNav';
 
 interface Account {
   id: number;
@@ -499,11 +500,18 @@ const CasTab: React.FC<CasTabProps> = ({ onShowToast, onNavigate }) => {
         <div className="flex items-center gap-3">
           <h2 className="text-xl font-bold text-slate-900">CAS 秒传</h2>
           <button
-            onClick={() => onNavigate?.('media')}
-            className="p-2 bg-white border border-slate-300 rounded-full hover:bg-slate-50 transition-all text-slate-600 shadow-sm"
-            title="在媒体设置中配置"
+            type="button"
+            onClick={() => {
+              try {
+                sessionStorage.setItem(MEDIA_SECTION_STORAGE_KEY, 'media-cas');
+              } catch {}
+              onNavigate?.('media');
+            }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-300 rounded-full hover:bg-slate-50 transition-all text-slate-600 shadow-sm text-sm"
+            title="在媒体设置中配置秒传"
           >
-            <Settings size={18} />
+            <Settings size={16} />
+            秒传设置
           </button>
         </div>
         <div className="flex items-center gap-3">

--- a/frontend/src/components/tabs/FileManagerTab.tsx
+++ b/frontend/src/components/tabs/FileManagerTab.tsx
@@ -516,8 +516,8 @@ const FileManagerTab: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-3xl border border-slate-200/60 p-4 flex flex-col md:flex-row md:items-center justify-between shadow-sm gap-4">
-        <div className="flex items-center flex-wrap gap-1 text-sm text-slate-500 px-2">
+      <div className="ui-card p-4 flex flex-col md:flex-row md:items-center justify-between shadow-sm gap-4">
+        <div className="flex items-center flex-wrap gap-1 text-sm ui-muted px-2">
           <Files size={18} className="mr-1" />
           {path.map((segment, index) => (
             <React.Fragment key={segment.id}>
@@ -542,13 +542,13 @@ const FileManagerTab: React.FC = () => {
               className="pl-10 pr-4 py-2 bg-slate-50 border border-slate-300 rounded-full text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20 w-56"
             />
           </div>
-          <span className="text-sm text-slate-500 font-medium whitespace-nowrap">
+          <span className="text-sm ui-muted font-medium whitespace-nowrap">
             {driveLabel && `${driveLabel} · `}共 {visibleEntries.length} 项
           </span>
         </div>
       </div>
 
-      <div className="bg-white rounded-3xl border border-slate-200/60 shadow-sm">
+      <div className="ui-card shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50/50 border-b border-slate-100">
@@ -598,7 +598,7 @@ const FileManagerTab: React.FC = () => {
                           {entry.isFolder ? <Folder size={20} /> : <FileText size={20} />}
                         </div>
                         <span 
-                          className={`font-medium text-slate-900 ${entry.isFolder ? 'cursor-pointer hover:text-[#0b57d0]' : ''}`}
+                          className={`font-medium ui-title ${entry.isFolder ? 'cursor-pointer hover:text-[#0b57d0]' : ''}`}
                           onClick={() => entry.isFolder && handleNavigate(entry.id, entry.name)}
                         >
                           {entry.name}

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -409,16 +409,16 @@ const MediaTab: React.FC = () => {
       {/* OpenAI / AI Settings */}
       <section id="media-ai" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-ai')}>
         <div className="flex items-center justify-between">
-          <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+          <h3 className="text-xl font-medium ui-title flex items-center gap-3">
             <Cpu size={24} className="text-[#0b57d0]" /> AI 辅助重命名
           </h3>
           <Switch checked={settings.openai.enable} onChange={(v) => updateSetting('openai.enable', v)} />
         </div>
         
-        <div className={`bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm transition-opacity ${!settings.openai.enable && 'opacity-60 pointer-events-none'}`}>
+        <div className={`ui-card p-8 space-y-6 shadow-sm transition-opacity ${!settings.openai.enable && 'opacity-60 pointer-events-none'}`}>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">API 地址</label>
+              <label className="text-sm font-medium ui-title">API 地址</label>
               <input 
                 type="text" 
                 value={settings.openai.baseUrl}
@@ -428,7 +428,7 @@ const MediaTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">API Key</label>
+              <label className="text-sm font-medium ui-title">API Key</label>
               <input
                 type="password"
                 value={settings.openai.apiKey}
@@ -440,7 +440,7 @@ const MediaTab: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">模型名称</label>
+              <label className="text-sm font-medium ui-title">模型名称</label>
               <input 
                 type="text" 
                 value={settings.openai.model}
@@ -450,7 +450,7 @@ const MediaTab: React.FC = () => {
               />
             </div>
             <div className="md:col-span-2 space-y-2">
-              <label className="text-sm font-medium text-slate-700">剧集命名模板</label>
+              <label className="text-sm font-medium ui-title">剧集命名模板</label>
               <input 
                 type="text" 
                 value={settings.openai.rename.template}
@@ -461,8 +461,8 @@ const MediaTab: React.FC = () => {
           </div>
           <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
             <div className="pr-6">
-              <p className="text-sm font-medium text-slate-900">AI API 流控</p>
-              <p className="text-xs text-slate-500">开启后会将 AI 请求串行排队，降低上游接口并发压力。</p>
+              <p className="text-sm font-medium ui-title">AI API 流控</p>
+              <p className="text-xs ui-muted">开启后会将 AI 请求串行排队，降低上游接口并发压力。</p>
             </div>
             <Switch
               checked={settings.openai.flowControlEnabled}
@@ -471,7 +471,7 @@ const MediaTab: React.FC = () => {
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">电影命名模板</label>
+            <label className="text-sm font-medium ui-title">电影命名模板</label>
             <input 
               type="text" 
               value={settings.openai.rename.movieTemplate}
@@ -490,10 +490,10 @@ const MediaTab: React.FC = () => {
 
       {/* STRM Settings */}
       <section id="media-strm" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-strm')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Link2 size={24} className="text-[#0b57d0]" /> STRM 设置
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="flex flex-col gap-4">
             <div className="p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
               <Checkbox
@@ -501,7 +501,7 @@ const MediaTab: React.FC = () => {
                 align="start"
                 checked={settings.strm.enable}
                 onChange={(v) => updateSetting('strm.enable', v)}
-                label={<span className="text-sm font-medium text-slate-900">启用 STRM 生成</span>}
+                label={<span className="text-sm font-medium ui-title">启用 STRM 生成</span>}
                 description="允许系统为转存任务生成 .strm 播放文件"
               />
             </div>
@@ -519,7 +519,7 @@ const MediaTab: React.FC = () => {
                 align="start"
                 checked={settings.strm.useStreamProxy}
                 onChange={(v) => updateSetting('strm.useStreamProxy', v)}
-                label={<span className="text-sm font-medium text-slate-900">普通任务使用系统中转</span>}
+                label={<span className="text-sm font-medium ui-title">普通任务使用系统中转</span>}
                 description="由服务端换取直链，避免临时直链过期"
               />
             </div>
@@ -529,10 +529,10 @@ const MediaTab: React.FC = () => {
 
       {/* CAS 秒传设置 */}
       <section id="media-cas" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-cas')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Zap size={24} className="text-[#0b57d0]" /> 秒传设置
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="flex flex-col gap-4">
             <label
               className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors"
@@ -546,7 +546,7 @@ const MediaTab: React.FC = () => {
                 {settings.cas.enableFamilyTransit && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">启用家庭中转</span>
+                <span className="text-sm font-medium ui-title">启用家庭中转</span>
                 <p className="text-[10px] text-slate-400">秒传时通过家庭云中转，规避个人云风控</p>
               </div>
             </label>
@@ -562,7 +562,7 @@ const MediaTab: React.FC = () => {
                 {settings.cas.familyTransitFirst && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">优先使用家庭中转</span>
+                <span className="text-sm font-medium ui-title">优先使用家庭中转</span>
                 <p className="text-[10px] text-slate-400">默认先尝试家庭云秒传，失败再回退个人云</p>
               </div>
             </label>
@@ -578,7 +578,7 @@ const MediaTab: React.FC = () => {
                 {settings.cas.deleteCasAfterRestore && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">恢复后删除 CAS 文件</span>
+                <span className="text-sm font-medium ui-title">恢复后删除 CAS 文件</span>
                 <p className="text-[10px] text-slate-400">秒传恢复成功后自动删除 .cas 存根文件</p>
               </div>
             </label>
@@ -594,7 +594,7 @@ const MediaTab: React.FC = () => {
                 {settings.cas.deleteSourceAfterGenerate && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">生成后删除源文件</span>
+                <span className="text-sm font-medium ui-title">生成后删除源文件</span>
                 <p className="text-[10px] text-slate-400">生成 .cas 存根后自动删除原始文件</p>
               </div>
             </label>
@@ -610,13 +610,13 @@ const MediaTab: React.FC = () => {
 
       {/* Emby Settings */}
       <section id="media-emby" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-emby')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Tv size={24} className="text-[#0b57d0]" /> Emby 设置
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Emby 地址</label>
+              <label className="text-sm font-medium ui-title">Emby 地址</label>
               <input
                 type="text"
                 value={settings.emby.serverUrl}
@@ -626,7 +626,7 @@ const MediaTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">API Key</label>
+              <label className="text-sm font-medium ui-title">API Key</label>
               <input
                 type="password"
                 value={settings.emby.apiKey}
@@ -636,7 +636,7 @@ const MediaTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">Webhook 密钥</label>
+              <label className="text-sm font-medium ui-title">Webhook 密钥</label>
               <div className="flex gap-3">
                 <input
                   type="password"
@@ -666,7 +666,7 @@ const MediaTab: React.FC = () => {
                 >
                   {settings.emby.enable && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
                 </div>
-                <span className="text-sm font-medium text-slate-900">启用 Emby 入库通知</span>
+                <span className="text-sm font-medium ui-title">启用 Emby 入库通知</span>
               </label>
             </div>
             <div className="flex items-center gap-6 flex-wrap">
@@ -679,11 +679,11 @@ const MediaTab: React.FC = () => {
                 >
                   {settings.emby.proxy.enable && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
                 </div>
-                <span className="text-sm font-medium text-slate-900">启用 Emby 反代播放</span>
+                <span className="text-sm font-medium ui-title">启用 Emby 反代播放</span>
               </label>
               {settings.emby.proxy.enable && (
                 <div className="flex items-center gap-3">
-                  <label className="text-sm font-medium text-slate-700">代理端口</label>
+                  <label className="text-sm font-medium ui-title">代理端口</label>
                   <input
                     type="number"
                     value={settings.emby.proxy.port}
@@ -703,13 +703,13 @@ const MediaTab: React.FC = () => {
                 >
                   {settings.emby.prewarm.enable && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
                 </div>
-                <span className="text-sm font-medium text-slate-900">启用下一集预热</span>
+                <span className="text-sm font-medium ui-title">启用下一集预热</span>
               </label>
             </div>
             {settings.emby.prewarm.enable && (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-slate-700">Sessions 轮询间隔(ms)</label>
+                  <label className="text-sm font-medium ui-title">Sessions 轮询间隔(ms)</label>
                   <input
                     type="number"
                     value={settings.emby.prewarm.sessionPollIntervalMs}
@@ -718,7 +718,7 @@ const MediaTab: React.FC = () => {
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-slate-700">预热去重时长(ms)</label>
+                  <label className="text-sm font-medium ui-title">预热去重时长(ms)</label>
                   <input
                     type="number"
                     value={settings.emby.prewarm.dedupeTtlMs}
@@ -734,13 +734,13 @@ const MediaTab: React.FC = () => {
 
       {/* CloudSaver Settings */}
       <section id="media-cloudsaver" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-cloudsaver')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Monitor size={24} className="text-[#0b57d0]" /> CloudSaver 设置
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="space-y-2 md:col-span-3">
-              <label className="text-sm font-medium text-slate-700">服务地址</label>
+              <label className="text-sm font-medium ui-title">服务地址</label>
               <input
                 type="text"
                 value={settings.cloudSaver.baseUrl}
@@ -750,7 +750,7 @@ const MediaTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">用户名</label>
+              <label className="text-sm font-medium ui-title">用户名</label>
               <input
                 type="text"
                 value={settings.cloudSaver.username}
@@ -759,7 +759,7 @@ const MediaTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">密码</label>
+              <label className="text-sm font-medium ui-title">密码</label>
               <input
                 type="password"
                 value={settings.cloudSaver.password}
@@ -775,14 +775,14 @@ const MediaTab: React.FC = () => {
       {/* Hdhive Settings */}
       <section id="media-hdhive" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-hdhive')}>
         <div className="flex items-center justify-between">
-          <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+          <h3 className="text-xl font-medium ui-title flex items-center gap-3">
             <Search size={24} className="text-[#0b57d0]" /> 影巢设置
           </h3>
           <Switch checked={settings.hdhive.enabled} onChange={(v) => updateSetting('hdhive.enabled', v)} />
         </div>
-        <div className={`bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm transition-opacity ${!settings.hdhive.enabled && 'opacity-60 pointer-events-none'}`}>
+        <div className={`ui-card p-8 space-y-6 shadow-sm transition-opacity ${!settings.hdhive.enabled && 'opacity-60 pointer-events-none'}`}>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">站点地址</label>
+            <label className="text-sm font-medium ui-title">站点地址</label>
             <input
               type="text"
               value={settings.hdhive.baseUrl}
@@ -792,7 +792,7 @@ const MediaTab: React.FC = () => {
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">网页登录 Cookie</label>
+            <label className="text-sm font-medium ui-title">网页登录 Cookie</label>
             <textarea
               value={settings.hdhive.cookie}
               onChange={e => updateSetting('hdhive.cookie', e.target.value)}
@@ -801,7 +801,7 @@ const MediaTab: React.FC = () => {
               className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20 resize-y min-h-[104px]"
             />
             {settings.hdhive.hasCookie && (
-              <p className="text-xs text-slate-500">已保存 Cookie，留空保存不会覆盖当前值。</p>
+              <p className="text-xs ui-muted">已保存 Cookie，留空保存不会覆盖当前值。</p>
             )}
           </div>
           <div className="bg-blue-50 p-4 rounded-2xl border border-blue-100 flex gap-3">
@@ -817,12 +817,12 @@ const MediaTab: React.FC = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <section id="media-bridge" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-bridge')}>
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+            <h3 className="text-xl font-medium ui-title flex items-center gap-3">
               <Globe size={24} className="text-[#0b57d0]" /> Alist 设置
             </h3>
             <Switch checked={settings.alist.enable} onChange={(v) => updateSetting('alist.enable', v)} />
           </div>
-          <div className={`bg-white rounded-3xl border border-slate-200/60 p-6 space-y-4 shadow-sm transition-opacity ${!settings.alist.enable && 'opacity-60 pointer-events-none'}`}>
+          <div className={`ui-card p-6 space-y-4 shadow-sm transition-opacity ${!settings.alist.enable && 'opacity-60 pointer-events-none'}`}>
             <div className="space-y-1">
               <label className="text-xs font-medium text-slate-500 block">Alist 地址</label>
               <input 
@@ -848,12 +848,12 @@ const MediaTab: React.FC = () => {
 
         <section id="media-oauth" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-oauth')}>
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+            <h3 className="text-xl font-medium ui-title flex items-center gap-3">
               <Search size={24} className="text-[#0b57d0]" /> TMDB 刮削
             </h3>
             <Switch checked={settings.tmdb.enableScraper} onChange={(v) => updateSetting('tmdb.enableScraper', v)} />
           </div>
-          <div className={`bg-white rounded-3xl border border-slate-200/60 p-6 space-y-4 shadow-sm transition-opacity ${!settings.tmdb.enableScraper && 'opacity-60 pointer-events-none'}`}>
+          <div className={`ui-card p-6 space-y-4 shadow-sm transition-opacity ${!settings.tmdb.enableScraper && 'opacity-60 pointer-events-none'}`}>
             <div className="space-y-1">
               <label className="text-xs font-medium text-slate-500 block">TMDB API Key</label>
               <input
@@ -871,10 +871,10 @@ const MediaTab: React.FC = () => {
 
       {/* Media Organizer Settings */}
       <section id="media-alist" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-alist')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Settings size={24} className="text-[#0b57d0]" /> 媒体库分类命名
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
             {Object.entries(settings.organizer.categories).map(([key, value]) => (
               <div key={key} className="space-y-1">
@@ -898,12 +898,12 @@ const MediaTab: React.FC = () => {
 
       {/* Regex Presets Management */}
       <section id="media-regex" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-regex')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Settings size={24} className="text-[#0b57d0]" /> 正则预设管理
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 shadow-sm">
+        <div className="ui-card p-8 shadow-sm">
           <div className="flex items-center justify-between mb-6">
-            <p className="text-sm text-slate-500">预设常用的重命名和筛选规则，一键套用于任务。</p>
+            <p className="text-sm ui-muted">预设常用的重命名和筛选规则，一键套用于任务。</p>
             <button 
               onClick={() => setIsRegexModalOpen(true)}
               className="px-6 py-2.5 bg-[#d3e3fd] text-[#041e49] rounded-full text-sm font-medium hover:bg-[#c2e7ff] transition-all flex items-center gap-2"
@@ -964,8 +964,8 @@ const MediaTab: React.FC = () => {
             {regexPresets.map((preset, index) => (
               <div key={index} className="p-4 bg-slate-50 rounded-2xl border border-slate-200 flex items-center justify-between group">
                 <div>
-                  <h4 className="font-bold text-slate-900 text-sm">{preset.name}</h4>
-                  <p className="text-xs text-slate-500 mt-0.5">{preset.description || '无描述'}</p>
+                  <h4 className="font-bold ui-title text-sm">{preset.name}</h4>
+                  <p className="text-xs ui-muted mt-0.5">{preset.description || '无描述'}</p>
                 </div>
                 <div className="flex gap-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                   <button 

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -167,19 +167,17 @@ const MediaTab: React.FC = () => {
   ];
   const [visibleSectionIds, setVisibleSectionIds] = useState<string[] | null>(null);
 
-  useEffect(() => {
-    try {
-      const target = sessionStorage.getItem(MEDIA_SECTION_STORAGE_KEY);
-      if (target) {
-        sessionStorage.removeItem(MEDIA_SECTION_STORAGE_KEY);
-        scrollToSettingsSection(target);
-      }
-    } catch {}
-  }, []);
   const dialog = useDialog();
   const [settings, setSettings] = useState<MediaSettings>(initialSettings);
   const [regexPresets, setRegexPresets] = useState<RegexPreset[]>([]);
   const [loading, setLoading] = useState(true);
+  const [pendingScrollSection, setPendingScrollSection] = useState<string | null>(() => {
+    try {
+      return sessionStorage.getItem(MEDIA_SECTION_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  });
   const [saving, setSaving] = useState(false);
   const [isRegexModalOpen, setIsRegexModalOpen] = useState(false);
   const [isEditRegexModalOpen, setIsEditRegexModalOpen] = useState(false);
@@ -287,6 +285,16 @@ const MediaTab: React.FC = () => {
       setLoading(false);
     }
   };
+
+  // CAS「秒传设置」跳转：等 loading 结束 DOM 有 section 后再滚
+  useEffect(() => {
+    if (loading || !pendingScrollSection) return;
+    try {
+      sessionStorage.removeItem(MEDIA_SECTION_STORAGE_KEY);
+    } catch {}
+    scrollToSettingsSection(pendingScrollSection);
+    setPendingScrollSection(null);
+  }, [loading, pendingScrollSection]);
 
   const handleSave = async () => {
     setSaving(true);

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -21,6 +21,7 @@ import Checkbox from '../ui/Checkbox';
 import Switch from '../ui/Switch';
 import { useToast } from '../ui/Toast';
 import { useDialog } from '../ui/Dialog';
+import SettingsNav, { type SettingsNavItem, scrollToSettingsSection, MEDIA_SECTION_STORAGE_KEY } from '../ui/SettingsNav';
 
 interface MediaSettings {
   strm: {
@@ -152,6 +153,29 @@ const initialSettings: MediaSettings = {
 
 const MediaTab: React.FC = () => {
   const toast = useToast();
+  const mediaNavItems: SettingsNavItem[] = [
+    { id: 'media-ai', label: 'AI 重命名', keywords: ['openai', 'ai', '重命名'] },
+    { id: 'media-strm', label: 'STRM', keywords: ['strm', '中转'] },
+    { id: 'media-cas', label: '秒传', keywords: ['cas', '秒传', '家庭中转'] },
+    { id: 'media-emby', label: 'Emby', keywords: ['emby', 'jellyfin'] },
+    { id: 'media-cloudsaver', label: 'CloudSaver', keywords: ['cloudsaver'] },
+    { id: 'media-hdhive', label: '影巢', keywords: ['hdhive', '影巢', 'cookie'] },
+    { id: 'media-bridge', label: 'Alist', keywords: ['alist'] },
+    { id: 'media-oauth', label: 'TMDB 刮削', keywords: ['tmdb', '刮削'] },
+    { id: 'media-alist', label: '媒体库分类', keywords: ['分类', 'organizer', '电影'] },
+    { id: 'media-regex', label: '正则预设', keywords: ['正则', 'regex'] },
+  ];
+  const [visibleSectionIds, setVisibleSectionIds] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    try {
+      const target = sessionStorage.getItem(MEDIA_SECTION_STORAGE_KEY);
+      if (target) {
+        sessionStorage.removeItem(MEDIA_SECTION_STORAGE_KEY);
+        scrollToSettingsSection(target);
+      }
+    } catch {}
+  }, []);
   const dialog = useDialog();
   const [settings, setSettings] = useState<MediaSettings>(initialSettings);
   const [regexPresets, setRegexPresets] = useState<RegexPreset[]>([]);
@@ -379,9 +403,11 @@ const MediaTab: React.FC = () => {
   }
 
   return (
-    <div className="max-w-4xl space-y-8 pb-12">
+    <div className="max-w-4xl space-y-8 pb-12 pb-8">
+      <SettingsNav items={mediaNavItems} onVisibleChange={setVisibleSectionIds} />
+
       {/* OpenAI / AI Settings */}
-      <section className="space-y-4">
+      <section id="media-ai" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-ai')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Cpu size={24} className="text-[#0b57d0]" /> AI 辅助重命名
@@ -463,7 +489,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* STRM Settings */}
-      <section className="space-y-4">
+      <section id="media-strm" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-strm')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Link2 size={24} className="text-[#0b57d0]" /> STRM 设置
         </h3>
@@ -502,7 +528,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* CAS 秒传设置 */}
-      <section className="space-y-4">
+      <section id="media-cas" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-cas')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Zap size={24} className="text-[#0b57d0]" /> 秒传设置
         </h3>
@@ -583,7 +609,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Emby Settings */}
-      <section className="space-y-4">
+      <section id="media-emby" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-emby')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Tv size={24} className="text-[#0b57d0]" /> Emby 设置
         </h3>
@@ -707,7 +733,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* CloudSaver Settings */}
-      <section className="space-y-4">
+      <section id="media-cloudsaver" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-cloudsaver')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Monitor size={24} className="text-[#0b57d0]" /> CloudSaver 设置
         </h3>
@@ -747,7 +773,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Hdhive Settings */}
-      <section className="space-y-4">
+      <section id="media-hdhive" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-hdhive')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Search size={24} className="text-[#0b57d0]" /> 影巢设置
@@ -789,7 +815,7 @@ const MediaTab: React.FC = () => {
 
       {/* Alist & TMDB */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <section className="space-y-4">
+        <section id="media-bridge" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-bridge')}>
           <div className="flex items-center justify-between">
             <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
               <Globe size={24} className="text-[#0b57d0]" /> Alist 设置
@@ -820,7 +846,7 @@ const MediaTab: React.FC = () => {
           </div>
         </section>
 
-        <section className="space-y-4">
+        <section id="media-oauth" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-oauth')}>
           <div className="flex items-center justify-between">
             <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
               <Search size={24} className="text-[#0b57d0]" /> TMDB 刮削
@@ -844,7 +870,7 @@ const MediaTab: React.FC = () => {
       </div>
 
       {/* Media Organizer Settings */}
-      <section className="space-y-4">
+      <section id="media-alist" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-alist')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Settings size={24} className="text-[#0b57d0]" /> 媒体库分类命名
         </h3>
@@ -871,7 +897,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Regex Presets Management */}
-      <section className="space-y-4">
+      <section id="media-regex" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('media-regex')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Settings size={24} className="text-[#0b57d0]" /> 正则预设管理
         </h3>
@@ -898,7 +924,7 @@ const MediaTab: React.FC = () => {
       </section>
 
       {/* Save Button */}
-      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10">
+      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10 pr-20 md:pr-24">
         <button 
           onClick={fetchData}
           className="px-8 py-3 bg-white border border-slate-300 text-slate-700 rounded-full font-medium shadow-lg hover:bg-slate-50 transition-all flex items-center gap-2"

--- a/frontend/src/components/tabs/OrganizerTab.tsx
+++ b/frontend/src/components/tabs/OrganizerTab.tsx
@@ -87,7 +87,7 @@ const OrganizerTab: React.FC = () => {
   return (
     <div className="space-y-6">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-        <h2 className="text-xl font-bold text-slate-900">整理器任务</h2>
+        <h2 className="text-xl font-bold ui-title">整理器任务</h2>
         <div className="flex items-center gap-3">
           <div className="relative w-64">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={16} />
@@ -114,7 +114,7 @@ const OrganizerTab: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+      <div className="ui-card overflow-hidden shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50/50 border-b border-slate-100">
@@ -154,7 +154,7 @@ const OrganizerTab: React.FC = () => {
                           {isRunning ? '执行中' : '执行整理'}
                         </button>
                       </td>
-                      <td className="px-6 py-4 font-medium text-slate-900">
+                      <td className="px-6 py-4 font-medium ui-title">
                         <div>{task.resourceName}</div>
                         {task.shareFolderName && (
                           <div className="text-xs text-slate-400 mt-0.5">{task.shareFolderName}</div>

--- a/frontend/src/components/tabs/PtTab.tsx
+++ b/frontend/src/components/tabs/PtTab.tsx
@@ -838,7 +838,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
         </div>
       </div>
 
-      <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+      <div className="ui-card overflow-hidden shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50/50 border-b border-slate-100">
@@ -866,7 +866,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                         <Magnet size={20} />
                       </div>
                       <div className="flex flex-col">
-                        <span className="font-medium text-slate-900 truncate max-w-[160px]" title={sub.name}>{sub.name}</span>
+                        <span className="font-medium ui-title truncate max-w-[160px]" title={sub.name}>{sub.name}</span>
                         {!sub.enabled && <span className="text-[10px] text-red-500 font-bold uppercase">已禁用</span>}
                       </div>
                     </div>
@@ -916,13 +916,13 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={editing ? '编辑 PT 订阅' : '添加 PT 订阅'} footer={null}>
         <form onSubmit={handleSave} className="space-y-5">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">订阅名称</label>
+            <label className="text-sm font-medium ui-title">订阅名称</label>
             <input type="text" required value={formData.name} onChange={e => setFormData({ ...formData, name: e.target.value })}
               className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20" />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">RSS 来源</label>
+            <label className="text-sm font-medium ui-title">RSS 来源</label>
             <select value={formData.sourcePreset} onChange={e => {
               const preset = presets.find(p => p.key === e.target.value);
               setFormData({
@@ -933,11 +933,11 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
             }} className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none">
               {presets.map(p => <option key={p.key} value={p.key}>{p.label}</option>)}
             </select>
-            <p className="text-xs text-slate-500">{presets.find(p => p.key === formData.sourcePreset)?.description || ''}</p>
+            <p className="text-xs ui-muted">{presets.find(p => p.key === formData.sourcePreset)?.description || ''}</p>
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">RSS URL</label>
+            <label className="text-sm font-medium ui-title">RSS URL</label>
             <div className="flex gap-2">
               <input type="text" value={formData.rssUrl} onChange={e => setFormData({ ...formData, rssUrl: e.target.value })}
                 placeholder={presets.find(p => p.key === formData.sourcePreset)?.defaultRssUrl || ''}
@@ -953,13 +953,13 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">包含正则（可选）</label>
+              <label className="text-sm font-medium ui-title">包含正则（可选）</label>
               <input type="text" value={formData.includePattern} onChange={e => setFormData({ ...formData, includePattern: e.target.value })}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs"
                 placeholder="例如: 1080p|2160p" />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">排除正则（可选）</label>
+              <label className="text-sm font-medium ui-title">排除正则（可选）</label>
               <input type="text" value={formData.excludePattern} onChange={e => setFormData({ ...formData, excludePattern: e.target.value })}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs"
                 placeholder="例如: cam|ts.x264" />
@@ -968,7 +968,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
 
           <div className="rounded-2xl border border-slate-200 overflow-hidden">
             <button type="button" onClick={() => setShowAdvanced(v => !v)}
-              className="w-full flex items-center justify-between px-4 py-3 bg-slate-50 hover:bg-slate-100 transition-colors text-sm font-medium text-slate-700">
+              className="w-full flex items-center justify-between px-4 py-3 bg-slate-50 hover:bg-slate-100 transition-colors text-sm font-medium ui-title">
               <span className="flex items-center gap-2"><Filter size={14} /> 高级规则（过滤 / 去重 / 备用 RSS / 集数）</span>
               {showAdvanced ? <ChevronDown size={16} className="text-slate-500" /> : <ChevronRight size={16} className="text-slate-500" />}
             </button>
@@ -976,21 +976,21 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
               <div className="p-4 space-y-4 bg-white">
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">分辨率正则</label>
+                    <label className="text-xs ui-muted">分辨率正则</label>
                     <input type="text" value={formData.resolutionPattern}
                       onChange={e => setFormData({ ...formData, resolutionPattern: e.target.value })}
                       placeholder="例如: 1080p|2160p"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none font-mono" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">质量正则</label>
+                    <label className="text-xs ui-muted">质量正则</label>
                     <input type="text" value={formData.qualityPattern}
                       onChange={e => setFormData({ ...formData, qualityPattern: e.target.value })}
                       placeholder="例如: BluRay|WEB-DL"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none font-mono" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">特效正则</label>
+                    <label className="text-xs ui-muted">特效正则</label>
                     <input type="text" value={formData.effectPattern}
                       onChange={e => setFormData({ ...formData, effectPattern: e.target.value })}
                       placeholder="例如: HDR|DV|Dolby"
@@ -1000,21 +1000,21 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">最小体积 (MB)</label>
+                    <label className="text-xs ui-muted">最小体积 (MB)</label>
                     <input type="number" min={0} value={formData.sizeMinMB}
                       onChange={e => setFormData({ ...formData, sizeMinMB: Number(e.target.value) || 0 })}
                       placeholder="0 = 不限"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">最大体积 (MB)</label>
+                    <label className="text-xs ui-muted">最大体积 (MB)</label>
                     <input type="number" min={0} value={formData.sizeMaxMB}
                       onChange={e => setFormData({ ...formData, sizeMaxMB: Number(e.target.value) || 0 })}
                       placeholder="0 = 不限"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">最少做种数</label>
+                    <label className="text-xs ui-muted">最少做种数</label>
                     <input type="number" min={0} value={formData.seedersMin}
                       onChange={e => setFormData({ ...formData, seedersMin: Number(e.target.value) || 0 })}
                       placeholder="0 = 不限"
@@ -1068,7 +1068,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                 </div>
 
                 <div className="space-y-1.5">
-                  <label className="text-xs text-slate-500">备用 RSS</label>
+                  <label className="text-xs ui-muted">备用 RSS</label>
                   <textarea
                     rows={3}
                     value={formData.standbyRssJson}
@@ -1080,28 +1080,28 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
 
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">延迟下载(分钟)</label>
+                    <label className="text-xs ui-muted">延迟下载(分钟)</label>
                     <input type="number" min={0} value={formData.delayedDownloadMinutes}
                       onChange={e => setFormData({ ...formData, delayedDownloadMinutes: Number(e.target.value) || 0 })}
                       placeholder="0 = 不延迟"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">不下载集数</label>
+                    <label className="text-xs ui-muted">不下载集数</label>
                     <input type="text" value={formData.notDownloadEpisodes}
                       onChange={e => setFormData({ ...formData, notDownloadEpisodes: e.target.value })}
                       placeholder="1, 3, 7-9"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none font-mono" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">集数偏移</label>
+                    <label className="text-xs ui-muted">集数偏移</label>
                     <input type="number" step="0.5" value={formData.episodeOffset}
                       onChange={e => setFormData({ ...formData, episodeOffset: Number(e.target.value) || 0 })}
                       placeholder="0"
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-xs outline-none" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-slate-500">总集数</label>
+                    <label className="text-xs ui-muted">总集数</label>
                     <input type="number" min={0} value={formData.totalEpisodeNumber}
                       onChange={e => setFormData({ ...formData, totalEpisodeNumber: Number(e.target.value) || 0 })}
                       placeholder="0 = 不限制"
@@ -1137,14 +1137,14 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                   {formData.customEpisode && (
                     <div className="grid grid-cols-1 md:grid-cols-[1fr_120px] gap-3">
                       <div className="space-y-1.5">
-                        <label className="text-xs text-slate-500">集数提取正则</label>
+                        <label className="text-xs ui-muted">集数提取正则</label>
                         <input type="text" value={formData.customEpisodeRegex}
                           onChange={e => setFormData({ ...formData, customEpisodeRegex: e.target.value })}
                           placeholder="例如: 第(\\d+)话"
                           className="w-full px-4 py-2.5 bg-white border border-slate-300 rounded-2xl text-xs outline-none font-mono" />
                       </div>
                       <div className="space-y-1.5">
-                        <label className="text-xs text-slate-500">分组序号</label>
+                        <label className="text-xs ui-muted">分组序号</label>
                         <input type="number" min={0} value={formData.customEpisodeGroupIndex}
                           onChange={e => setFormData({ ...formData, customEpisodeGroupIndex: Number(e.target.value) || 1 })}
                           className="w-full px-4 py-2.5 bg-white border border-slate-300 rounded-2xl text-xs outline-none" />
@@ -1160,7 +1160,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">天翼云盘账号</label>
+            <label className="text-sm font-medium ui-title">天翼云盘账号</label>
             <select value={formData.accountId} onChange={e => setFormData({ ...formData, accountId: Number(e.target.value), targetFolderId: '', targetFolder: '' })}
               className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" required>
               <option value={0}>请选择</option>
@@ -1169,7 +1169,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">目标目录</label>
+            <label className="text-sm font-medium ui-title">目标目录</label>
             <div className="flex gap-2">
               <input type="text" readOnly value={formData.targetFolder || formData.targetFolderId} placeholder="点击右侧按钮选择目录"
                 className="flex-1 px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
@@ -1238,7 +1238,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                   return (
                   <tr key={rel.id} className="hover:bg-slate-50/50">
                     <td className="px-4 py-3">
-                      <div className="font-medium text-slate-900 truncate max-w-[300px]" title={rel.title}>{rel.title}</div>
+                      <div className="font-medium ui-title truncate max-w-[300px]" title={rel.title}>{rel.title}</div>
                       {(sizeText || rel.seeders != null && rel.seeders > 0 || factorText || rel.subgroup || episodeBadge || rel.resolution || rel.quality || tags.length > 0) && (
                         <div className="flex flex-wrap items-center gap-2 mt-1 text-[11px] text-slate-500">
                           {rel.subgroup && (
@@ -1288,7 +1288,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                       <div className="flex items-center gap-2">
                         <span className={`px-2 py-1 rounded-full text-xs ${statusColor(rel.status)}`}>{statusLabel(rel.status)}</span>
                         {(rel.status === 'downloading' || rel.status === 'uploading') && rel.progress != null && rel.progress > 0 && (
-                          <span className="text-xs text-slate-500 font-mono">{rel.progress}%</span>
+                          <span className="text-xs ui-muted font-mono">{rel.progress}%</span>
                         )}
                       </div>
                       {(rel.status === 'downloading' || rel.status === 'uploading') && rel.progress != null && rel.progress > 0 && (
@@ -1325,25 +1325,25 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
               <div className="flex items-center gap-2 text-sm font-medium text-slate-800"><Download size={16} /> 下载客户端</div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2 md:col-span-2">
-                  <label className="text-xs text-slate-500">类型</label>
+                  <label className="text-xs ui-muted">类型</label>
                   <select value={settings.downloader.type} onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, type: e.target.value } })}
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none">
                     <option value="qbittorrent">qBittorrent</option>
                   </select>
                 </div>
                 <div className="space-y-2 md:col-span-2">
-                  <label className="text-xs text-slate-500">WebUI 地址</label>
+                  <label className="text-xs ui-muted">WebUI 地址</label>
                   <input type="text" value={settings.downloader.baseUrl} onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, baseUrl: e.target.value } })}
                     placeholder="http://192.168.1.10:8080"
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs" />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-xs text-slate-500">用户名</label>
+                  <label className="text-xs ui-muted">用户名</label>
                   <input type="text" value={settings.downloader.username} onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, username: e.target.value } })}
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-xs text-slate-500">密码</label>
+                  <label className="text-xs ui-muted">密码</label>
                   <input
                     type="password"
                     value={settings.downloader.password}
@@ -1353,12 +1353,12 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-xs text-slate-500">分类前缀</label>
+                  <label className="text-xs ui-muted">分类前缀</label>
                   <input type="text" value={settings.downloader.categoryPrefix} onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, categoryPrefix: e.target.value } })}
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-xs text-slate-500">标签前缀</label>
+                  <label className="text-xs ui-muted">标签前缀</label>
                   <input type="text" value={settings.downloader.tagPrefix} onChange={e => setSettings({ ...settings, downloader: { ...settings.downloader, tagPrefix: e.target.value } })}
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
                 </div>
@@ -1386,24 +1386,24 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
             <div className="rounded-2xl border border-slate-200 p-4 space-y-4">
               <div className="text-sm font-medium text-slate-800">下载与定时</div>
               <div className="space-y-2">
-                <label className="text-xs text-slate-500">下载根目录（容器内可见路径）</label>
+                <label className="text-xs ui-muted">下载根目录（容器内可见路径）</label>
                 <input type="text" value={settings.downloadRoot} onChange={e => setSettings({ ...settings, downloadRoot: e.target.value })}
                   placeholder="例如：/downloads/pt" className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs" />
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <label className="text-xs text-slate-500">RSS 拉取 cron</label>
+                  <label className="text-xs ui-muted">RSS 拉取 cron</label>
                   <input type="text" value={settings.pollCron} onChange={e => setSettings({ ...settings, pollCron: e.target.value })}
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs" />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-xs text-slate-500">清理 cron</label>
+                  <label className="text-xs ui-muted">清理 cron</label>
                   <input type="text" value={settings.cleanupCron} onChange={e => setSettings({ ...settings, cleanupCron: e.target.value })}
                     className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs" />
                 </div>
               </div>
               <div className="space-y-2">
-                <label className="text-xs text-slate-500">全局排除正则</label>
+                <label className="text-xs ui-muted">全局排除正则</label>
                 <textarea
                   rows={3}
                   value={settings.globalExcludePattern}
@@ -1457,7 +1457,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
               {settings.strmOrganize.enabled && (
                 <>
                   <div className="space-y-2">
-                    <label className="text-xs text-slate-500">整理模式</label>
+                    <label className="text-xs ui-muted">整理模式</label>
                     <select value={settings.strmOrganize.mode}
                       onChange={e => setSettings({ ...settings, strmOrganize: { ...settings.strmOrganize, mode: e.target.value as 'regex' | 'ai' } })}
                       className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none">
@@ -1469,14 +1469,14 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                   {settings.strmOrganize.mode === 'regex' && (
                     <>
                       <div className="space-y-2">
-                        <label className="text-xs text-slate-500">分类目录名</label>
+                        <label className="text-xs ui-muted">分类目录名</label>
                         <input type="text" value={settings.strmOrganize.categoryFolder}
                           onChange={e => setSettings({ ...settings, strmOrganize: { ...settings.strmOrganize, categoryFolder: e.target.value } })}
                           placeholder="动漫"
                           className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
                       </div>
                       <div className="space-y-2">
-                        <label className="text-xs text-slate-500">文件名模板</label>
+                        <label className="text-xs ui-muted">文件名模板</label>
                         <input type="text" value={settings.strmOrganize.fileTemplate}
                           onChange={e => setSettings({ ...settings, strmOrganize: { ...settings.strmOrganize, fileTemplate: e.target.value } })}
                           placeholder="{title} S{season}E{episode}"
@@ -1485,14 +1485,14 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                       </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div className="space-y-2">
-                          <label className="text-xs text-slate-500">季度提取正则（留空用默认）</label>
+                          <label className="text-xs ui-muted">季度提取正则（留空用默认）</label>
                           <input type="text" value={settings.strmOrganize.seasonRegex}
                             onChange={e => setSettings({ ...settings, strmOrganize: { ...settings.strmOrganize, seasonRegex: e.target.value } })}
                             placeholder="S(\d{1,2})|第(\d+)季"
                             className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none font-mono text-xs" />
                         </div>
                         <div className="space-y-2">
-                          <label className="text-xs text-slate-500">集数提取正则（留空用默认）</label>
+                          <label className="text-xs ui-muted">集数提取正则（留空用默认）</label>
                           <input type="text" value={settings.strmOrganize.episodeRegex}
                             onChange={e => setSettings({ ...settings, strmOrganize: { ...settings.strmOrganize, episodeRegex: e.target.value } })}
                             placeholder="第\d+[话話集]|EP?\d+"
@@ -1500,7 +1500,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                         </div>
                       </div>
                       <div className="space-y-2">
-                        <label className="text-xs text-slate-500">默认季度（当无法提取时）</label>
+                        <label className="text-xs ui-muted">默认季度（当无法提取时）</label>
                         <input type="number" value={settings.strmOrganize.defaultSeason} min={1}
                           onChange={e => setSettings({ ...settings, strmOrganize: { ...settings.strmOrganize, defaultSeason: Number(e.target.value) } })}
                           className="w-full px-4 py-2.5 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none" />
@@ -1509,7 +1509,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                   )}
 
                   {settings.strmOrganize.mode === 'ai' && (
-                    <div className="text-xs text-slate-500 bg-slate-50 p-3 rounded-xl">
+                    <div className="text-xs ui-muted bg-slate-50 p-3 rounded-xl">
                       AI 模式需要在系统设置中配置 OpenAI 和 TMDB API Key。整理器会自动识别番剧信息并整理目录结构。
                     </div>
                   )}
@@ -1518,7 +1518,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
             </div>
 
             <div className="border-t border-slate-200 pt-4 mt-4">
-              <h3 className="text-sm font-medium text-slate-700 mb-3">站点代理（需在系统设置中配置代理服务器）</h3>
+              <h3 className="text-sm font-medium ui-title mb-3">站点代理（需在系统设置中配置代理服务器）</h3>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                 {[
                   { key: 'ptMikan', label: '蜜柑计划' },
@@ -1616,7 +1616,7 @@ const PtTab: React.FC<PtTabProps> = ({ prefill, onPrefillConsumed }) => {
                         {group.itemCount != null && <div className="text-xs text-slate-400">{group.itemCount} 个资源</div>}
                       </button>
                       <button type="button" onClick={(e) => { e.stopPropagation(); handlePreviewGroup(idx, group); }}
-                        className="ml-2 px-3 py-1.5 text-xs text-slate-500 hover:text-[#0b57d0] hover:bg-[#0b57d0]/10 rounded-full transition-colors">
+                        className="ml-2 px-3 py-1.5 text-xs ui-muted hover:text-[#0b57d0] hover:bg-[#0b57d0]/10 rounded-full transition-colors">
                         {previewGroupIdx === idx ? '收起' : '预览'}
                       </button>
                     </div>

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -6,6 +6,7 @@ import Checkbox from '../ui/Checkbox';
 import Switch from '../ui/Switch';
 import { useToast } from '../ui/Toast';
 import { useDialog } from '../ui/Dialog';
+import SettingsNav, { type SettingsNavItem } from '../ui/SettingsNav';
 
 const parseIntOr = (raw: string, fallback: number) => {
   if (raw === '' || raw === '-' ) return fallback;
@@ -264,6 +265,17 @@ const initialSettings: SettingsData = {
 const SettingsTab: React.FC = () => {
   const toast = useToast();
   const dialog = useDialog();
+  const settingsNavItems: SettingsNavItem[] = [
+    { id: 'settings-auth', label: '访问认证', keywords: ['认证', '用户名', '密码', 'api'] },
+    { id: 'settings-task', label: '任务设置', keywords: ['任务', '过期', '重试', 'cron', '回收站'] },
+    { id: 'settings-telegram', label: 'Telegram', keywords: ['telegram', 'tg', 'bot'] },
+    { id: 'settings-push', label: '消息推送', keywords: ['推送', '企业微信', 'bark', 'pushplus'] },
+    { id: 'settings-proxy', label: '网络代理', keywords: ['代理', 'proxy'] },
+    { id: 'settings-hdhive', label: '影巢资源', keywords: ['影巢', 'hdhive'] },
+    { id: 'settings-custom-push', label: '自定义推送', keywords: ['自定义推送', 'webhook'] },
+    { id: 'settings-regex', label: '正则预设', keywords: ['正则', 'regex'] },
+  ];
+  const [visibleSectionIds, setVisibleSectionIds] = useState<string[] | null>(null);
   const [settings, setSettings] = useState<SettingsData>(initialSettings);
   const [accounts, setAccounts] = useState<{id: number, username: string, alias?: string}[]>([]);
   const [loading, setLoading] = useState(true);
@@ -610,9 +622,11 @@ const SettingsTab: React.FC = () => {
   const selectedAccount = accounts.find(a => String(a.id) === settings.task.autoCreate.accountId);
 
   return (
-    <div className="max-w-4xl space-y-8">
+    <div className="max-w-4xl space-y-8 pb-8">
+      <SettingsNav items={settingsNavItems} onVisibleChange={setVisibleSectionIds} />
+
       {/* System Credentials */}
-      <section className="space-y-4">
+      <section id="settings-auth" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-auth')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Shield size={24} className="text-[#0b57d0]" /> 访问认证
         </h3>
@@ -660,7 +674,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Task Settings */}
-      <section className="space-y-4">
+      <section id="settings-task" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-task')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Database size={24} className="text-[#0b57d0]" /> 任务设置
         </h3>
@@ -908,7 +922,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Telegram Bot Settings */}
-      <section className="space-y-4">
+      <section id="settings-telegram" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-telegram')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Send size={24} className="text-[#0b57d0]" /> Telegram 机器人
@@ -1040,7 +1054,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Push Notifications */}
-      <section className="space-y-4">
+      <section id="settings-push" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-push')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Bell size={24} className="text-[#b3261e]" /> 消息推送
         </h3>
@@ -1211,7 +1225,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Network Proxy */}
-      <section className="space-y-4">
+      <section id="settings-proxy" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-proxy')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Globe size={24} className="text-[#0b57d0]" /> 网络代理
         </h3>
@@ -1282,7 +1296,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* HDHive */}
-      <section className="space-y-4">
+      <section id="settings-hdhive" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-hdhive')}>
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
             <Search size={24} className="text-[#0b57d0]" /> 影巢资源
@@ -1462,7 +1476,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Custom Push Management */}
-      <section className="space-y-4">
+      <section id="settings-custom-push" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-custom-push')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Bell size={24} className="text-[#b3261e]" /> 自定义推送列表
         </h3>
@@ -1532,7 +1546,7 @@ const SettingsTab: React.FC = () => {
       </section>
 
       {/* Regex Presets Management */}
-      <section className="space-y-4">
+      <section id="settings-regex" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-regex')}>
         <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
           <Cpu size={24} className="text-[#0b57d0]" /> 正则预设列表
         </h3>
@@ -1606,7 +1620,7 @@ const SettingsTab: React.FC = () => {
         </div>
       </section>
 
-      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10">
+      <div className="flex justify-end pt-4 gap-4 sticky bottom-8 z-10 pr-20 md:pr-24">
         <button 
           type="button"
           onClick={loadSettings}

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -627,13 +627,13 @@ const SettingsTab: React.FC = () => {
 
       {/* System Credentials */}
       <section id="settings-auth" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-auth')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Shield size={24} className="text-[#0b57d0]" /> 访问认证
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">管理员用户名</label>
+              <label className="text-sm font-medium ui-title">管理员用户名</label>
               <input 
                 type="text" 
                 value={settings.system.username}
@@ -642,7 +642,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">管理员密码</label>
+              <label className="text-sm font-medium ui-title">管理员密码</label>
               <input 
                 type="password" 
                 value={settings.system.password}
@@ -653,7 +653,7 @@ const SettingsTab: React.FC = () => {
             </div>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">系统 API Key</label>
+            <label className="text-sm font-medium ui-title">系统 API Key</label>
             <div className="flex gap-3">
               <input
                 type="password"
@@ -675,13 +675,13 @@ const SettingsTab: React.FC = () => {
 
       {/* Task Settings */}
       <section id="settings-task" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-task')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Database size={24} className="text-[#0b57d0]" /> 任务设置
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">任务过期天数</label>
+              <label className="text-sm font-medium ui-title">任务过期天数</label>
               <input 
                 type="number" 
                 value={settings.task.taskExpireDays}
@@ -690,7 +690,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">最大重试次数</label>
+              <label className="text-sm font-medium ui-title">最大重试次数</label>
               <input 
                 type="number" 
                 value={settings.task.maxRetries}
@@ -699,7 +699,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">重试间隔 (秒)</label>
+              <label className="text-sm font-medium ui-title">重试间隔 (秒)</label>
               <input 
                 type="number" 
                 value={settings.task.retryInterval}
@@ -710,7 +710,7 @@ const SettingsTab: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">任务检查定时 (Cron)</label>
+              <label className="text-sm font-medium ui-title">任务检查定时 (Cron)</label>
               <input 
                 type="text" 
                 value={settings.task.taskCheckCron}
@@ -719,7 +719,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">回收站清理定时 (Cron)</label>
+              <label className="text-sm font-medium ui-title">回收站清理定时 (Cron)</label>
               <input 
                 type="text" 
                 value={settings.task.cleanRecycleCron}
@@ -728,7 +728,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">懒转存清理定时 (Cron)</label>
+              <label className="text-sm font-medium ui-title">懒转存清理定时 (Cron)</label>
               <input 
                 type="text" 
                 value={settings.task.lazyFileCleanupCron}
@@ -737,7 +737,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Session 保活定时 (Cron)</label>
+              <label className="text-sm font-medium ui-title">Session 保活定时 (Cron)</label>
               <input
                 type="text"
                 value={settings.task.sessionKeepAliveCron}
@@ -746,7 +746,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">懒转存保留时间 (小时)</label>
+              <label className="text-sm font-medium ui-title">懒转存保留时间 (小时)</label>
               <input 
                 type="number" 
                 value={settings.task.lazyFileRetentionHours}
@@ -755,7 +755,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">媒体文件后缀</label>
+              <label className="text-sm font-medium ui-title">媒体文件后缀</label>
               <input 
                 type="text" 
                 value={settings.task.mediaSuffix}
@@ -776,7 +776,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableAutoClearRecycle && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">自动清空回收站</span>
+                <span className="text-sm font-medium ui-title">自动清空回收站</span>
                 <p className="text-[10px] text-slate-400">定期清理个人云回收站</p>
               </div>
             </label>
@@ -790,7 +790,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableAutoClearFamilyRecycle && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">自动清理家庭云回收站</span>
+                <span className="text-sm font-medium ui-title">自动清理家庭云回收站</span>
               </div>
             </label>
             <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
@@ -803,7 +803,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableAutoCleanLazyFiles && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">自动清理懒转存文件</span>
+                <span className="text-sm font-medium ui-title">自动清理懒转存文件</span>
               </div>
             </label>
             <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
@@ -816,7 +816,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableOnlySaveMedia && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">仅转存媒体文件</span>
+                <span className="text-sm font-medium ui-title">仅转存媒体文件</span>
                 <p className="text-[10px] text-slate-400">
                   跳过图片、文档等非媒体文件。推荐开启：图片与视频同批转存时，违规图片可能导致整批失败（InfosecuMD5CheckError）。
                 </p>
@@ -832,7 +832,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableAutoCreateFolder && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">目标文件夹自动创建</span>
+                <span className="text-sm font-medium ui-title">目标文件夹自动创建</span>
               </div>
             </label>
             <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
@@ -845,7 +845,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableStorageAggregation && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">账号容量聚合</span>
+                <span className="text-sm font-medium ui-title">账号容量聚合</span>
                 <p className="text-[10px] text-slate-400">账号页显示多账号容量汇总</p>
               </div>
             </label>
@@ -859,7 +859,7 @@ const SettingsTab: React.FC = () => {
                 {settings.task.enableSessionKeepAlive && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">账号 Session 保活</span>
+                <span className="text-sm font-medium ui-title">账号 Session 保活</span>
                 <p className="text-[10px] text-slate-400">定时刷新账号会话</p>
               </div>
             </label>
@@ -870,7 +870,7 @@ const SettingsTab: React.FC = () => {
               type="button"
               onClick={runKeepAlive}
               disabled={keepAliveRunning}
-              className="px-5 py-3 bg-white border border-slate-300 rounded-2xl text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors flex items-center gap-2 disabled:opacity-60"
+              className="px-5 py-3 bg-white border border-slate-300 rounded-2xl text-sm font-medium ui-title hover:bg-slate-50 transition-colors flex items-center gap-2 disabled:opacity-60"
             >
               <RefreshCw size={18} className={keepAliveRunning ? 'animate-spin' : ''} />
               立即执行账号保活
@@ -879,12 +879,12 @@ const SettingsTab: React.FC = () => {
 
           {/* Auto Series Defaults */}
           <div className="pt-6 border-t border-slate-100 space-y-4">
-            <h4 className="text-sm font-bold text-slate-900 flex items-center gap-2">
+            <h4 className="text-sm font-bold ui-title flex items-center gap-2">
               <PlayCircle size={18} className="text-[#0b57d0]" /> 自动追剧默认配置
             </h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-700">默认追剧账号</label>
+                <label className="text-sm font-medium ui-title">默认追剧账号</label>
                 <select 
                   value={settings.task.autoCreate.accountId}
                   onChange={(e) => updateSettings('task.autoCreate.accountId', e.target.value)}
@@ -897,7 +897,7 @@ const SettingsTab: React.FC = () => {
                 </select>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-700">默认保存目录</label>
+                <label className="text-sm font-medium ui-title">默认保存目录</label>
                 <div className="flex gap-2">
                   <input 
                     type="text" 
@@ -924,7 +924,7 @@ const SettingsTab: React.FC = () => {
       {/* Telegram Bot Settings */}
       <section id="settings-telegram" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-telegram')}>
         <div className="flex items-center justify-between">
-          <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+          <h3 className="text-xl font-medium ui-title flex items-center gap-3">
             <Send size={24} className="text-[#0b57d0]" /> Telegram 机器人
           </h3>
           <Switch
@@ -935,8 +935,8 @@ const SettingsTab: React.FC = () => {
             }}
           />
         </div>
-        <div className={`bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm transition-opacity ${!settings.telegram.bot.enable && 'opacity-60 pointer-events-none'}`}>
-          <div className="text-xs text-slate-500 bg-slate-50 p-4 rounded-2xl border border-slate-100 leading-relaxed space-y-2">
+        <div className={`ui-card p-8 space-y-6 shadow-sm transition-opacity ${!settings.telegram.bot.enable && 'opacity-60 pointer-events-none'}`}>
+          <div className="text-xs ui-muted bg-slate-50 p-4 rounded-2xl border border-slate-100 leading-relaxed space-y-2">
             <p>启用后，你可以通过 Telegram 机器人直接管理任务、切换账号、搜索资源以及接收任务状态推送。</p>
             <p>1. Bot Token 可通过 @BotFather 创建机器人后获取。</p>
             <p>2. Chat ID 需要先给机器人发消息，再从更新记录或测试消息里确认。</p>
@@ -944,7 +944,7 @@ const SettingsTab: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Bot Token</label>
+              <label className="text-sm font-medium ui-title">Bot Token</label>
               <input
                 type="password"
                 value={settings.telegram.bot.botToken}
@@ -957,7 +957,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">默认 Chat ID</label>
+              <label className="text-sm font-medium ui-title">默认 Chat ID</label>
               <input
                 type="text"
                 value={settings.telegram.bot.chatId}
@@ -970,7 +970,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">反代 API 域名 (可选)</label>
+              <label className="text-sm font-medium ui-title">反代 API 域名 (可选)</label>
               <input
                 type="text"
                 value={settings.telegram.proxyDomain}
@@ -980,7 +980,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">允许使用的 Chat ID 列表</label>
+              <label className="text-sm font-medium ui-title">允许使用的 Chat ID 列表</label>
               <textarea
                 value={(settings.telegram.bot.allowedChatIds || []).join('\n')}
                 onChange={(e) => updateSettings('telegram.bot.allowedChatIds', parseIdList(e.target.value))}
@@ -990,7 +990,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">管理员 Chat ID 列表</label>
+              <label className="text-sm font-medium ui-title">管理员 Chat ID 列表</label>
               <textarea
                 value={(settings.telegram.bot.adminChatIds || []).join('\n')}
                 onChange={(e) => updateSettings('telegram.bot.adminChatIds', parseIdList(e.target.value))}
@@ -1011,7 +1011,7 @@ const SettingsTab: React.FC = () => {
                 {settings.telegram.notifyOnSuccess && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">成功通知</span>
+                <span className="text-sm font-medium ui-title">成功通知</span>
               </div>
             </label>
             <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
@@ -1024,7 +1024,7 @@ const SettingsTab: React.FC = () => {
                 {settings.telegram.notifyOnFailure && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">失败通知</span>
+                <span className="text-sm font-medium ui-title">失败通知</span>
               </div>
             </label>
             <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
@@ -1037,7 +1037,7 @@ const SettingsTab: React.FC = () => {
                 {settings.telegram.notifyOnScrape && <div className="w-2.5 h-2.5 bg-white rounded-sm" />}
               </div>
               <div>
-                <span className="text-sm font-medium text-slate-900">刮削通知</span>
+                <span className="text-sm font-medium ui-title">刮削通知</span>
               </div>
             </label>
           </div>
@@ -1045,7 +1045,7 @@ const SettingsTab: React.FC = () => {
             <button
               type="button"
               onClick={testTelegramConfig}
-              className="px-5 py-3 bg-white border border-slate-300 rounded-2xl text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors"
+              className="px-5 py-3 bg-white border border-slate-300 rounded-2xl text-sm font-medium ui-title hover:bg-slate-50 transition-colors"
             >
               测试配置
             </button>
@@ -1055,10 +1055,10 @@ const SettingsTab: React.FC = () => {
 
       {/* Push Notifications */}
       <section id="settings-push" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-push')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Bell size={24} className="text-[#b3261e]" /> 消息推送
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           {/* WeCom */}
           <div className="space-y-4">
             <div className="flex items-center justify-between p-4 bg-slate-50 rounded-2xl border border-slate-100">
@@ -1067,8 +1067,8 @@ const SettingsTab: React.FC = () => {
                   <MessageSquare size={20} />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-slate-900">企业微信推送</p>
-                  <p className="text-xs text-slate-500">通过 Webhook 推送任务状态</p>
+                  <p className="text-sm font-medium ui-title">企业微信推送</p>
+                  <p className="text-xs ui-muted">通过 Webhook 推送任务状态</p>
                 </div>
               </div>
               <Switch checked={settings.wecom.enable} onChange={(v) => updateSettings('wecom.enable', v)} />
@@ -1095,8 +1095,8 @@ const SettingsTab: React.FC = () => {
                   <Bell size={20} />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-slate-900">Bark 推送</p>
-                  <p className="text-xs text-slate-500">iOS Bark App，服务端地址 + 设备 Key</p>
+                  <p className="text-sm font-medium ui-title">Bark 推送</p>
+                  <p className="text-xs ui-muted">iOS Bark App，服务端地址 + 设备 Key</p>
                 </div>
               </div>
               <Switch checked={settings.bark.enable} onChange={(v) => updateSettings('bark.enable', v)} />
@@ -1135,8 +1135,8 @@ const SettingsTab: React.FC = () => {
                   <MessageSquare size={20} />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-slate-900">WxPusher</p>
-                  <p className="text-xs text-slate-500">简单推送 SPT，微信接收通知</p>
+                  <p className="text-sm font-medium ui-title">WxPusher</p>
+                  <p className="text-xs ui-muted">简单推送 SPT，微信接收通知</p>
                 </div>
               </div>
               <Switch checked={settings.wxpusher.enable} onChange={(v) => updateSettings('wxpusher.enable', v)} />
@@ -1163,8 +1163,8 @@ const SettingsTab: React.FC = () => {
                   <Bell size={20} />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-slate-900">PushPlus</p>
-                  <p className="text-xs text-slate-500">Token 推送，可选群组与渠道</p>
+                  <p className="text-sm font-medium ui-title">PushPlus</p>
+                  <p className="text-xs ui-muted">Token 推送，可选群组与渠道</p>
                 </div>
               </div>
               <Switch checked={settings.pushplus.enable} onChange={(v) => updateSettings('pushplus.enable', v)} />
@@ -1226,13 +1226,13 @@ const SettingsTab: React.FC = () => {
 
       {/* Network Proxy */}
       <section id="settings-proxy" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-proxy')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Globe size={24} className="text-[#0b57d0]" /> 网络代理
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">代理地址</label>
+              <label className="text-sm font-medium ui-title">代理地址</label>
               <input 
                 type="text" 
                 value={settings.proxy.host}
@@ -1242,7 +1242,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">代理端口</label>
+              <label className="text-sm font-medium ui-title">代理端口</label>
               <input 
                 type="number" 
                 value={settings.proxy.port}
@@ -1254,7 +1254,7 @@ const SettingsTab: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">代理用户名</label>
+              <label className="text-sm font-medium ui-title">代理用户名</label>
               <input 
                 type="text" 
                 value={settings.proxy.username}
@@ -1263,7 +1263,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">代理密码</label>
+              <label className="text-sm font-medium ui-title">代理密码</label>
               <input
                 type="password"
                 value={settings.proxy.password}
@@ -1298,18 +1298,18 @@ const SettingsTab: React.FC = () => {
       {/* HDHive */}
       <section id="settings-hdhive" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-hdhive')}>
         <div className="flex items-center justify-between">
-          <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+          <h3 className="text-xl font-medium ui-title flex items-center gap-3">
             <Search size={24} className="text-[#0b57d0]" /> 影巢资源
           </h3>
           <Switch checked={settings.hdhive.enabled} onChange={(v) => updateSettings('hdhive.enabled', v)} />
         </div>
-        <div className={`bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm transition-opacity ${!settings.hdhive.enabled && 'opacity-60'}`}>
-          <div className="text-xs text-slate-500 bg-slate-50 p-4 rounded-2xl border border-slate-100 leading-relaxed">
+        <div className={`ui-card p-8 space-y-6 shadow-sm transition-opacity ${!settings.hdhive.enabled && 'opacity-60'}`}>
+          <div className="text-xs ui-muted bg-slate-50 p-4 rounded-2xl border border-slate-100 leading-relaxed">
             支持 Cookie 网页解析、OpenAPI OAuth 和 Browser Bridge 签名网页模式。敏感凭证如已保存或通过环境变量配置，可保持输入框为空。
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">影巢站点地址</label>
+              <label className="text-sm font-medium ui-title">影巢站点地址</label>
               <input
                 type="url"
                 value={settings.hdhive.baseUrl}
@@ -1319,7 +1319,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Client ID</label>
+              <label className="text-sm font-medium ui-title">Client ID</label>
               <input
                 type="text"
                 value={settings.hdhive.clientId}
@@ -1329,7 +1329,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">网页登录账号</label>
+              <label className="text-sm font-medium ui-title">网页登录账号</label>
               <input
                 type="text"
                 value={settings.hdhive.username}
@@ -1339,7 +1339,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">网页登录密码</label>
+              <label className="text-sm font-medium ui-title">网页登录密码</label>
               <input
                 type="password"
                 value={settings.hdhive.password}
@@ -1349,7 +1349,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">Cookie</label>
+              <label className="text-sm font-medium ui-title">Cookie</label>
               <textarea
                 rows={3}
                 value={settings.hdhive.cookie}
@@ -1359,7 +1359,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Browser Bridge 地址</label>
+              <label className="text-sm font-medium ui-title">Browser Bridge 地址</label>
               <input
                 type="url"
                 value={settings.hdhive.browserBridge.baseUrl}
@@ -1369,7 +1369,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Browser Bridge Token</label>
+              <label className="text-sm font-medium ui-title">Browser Bridge Token</label>
               <input
                 type="password"
                 value={settings.hdhive.browserBridge.token}
@@ -1381,14 +1381,14 @@ const SettingsTab: React.FC = () => {
             <div className="space-y-2 md:col-span-2">
               <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
                 <div>
-                  <div className="text-sm font-medium text-slate-700">启用 Browser Bridge 签名模式</div>
-                  <div className="mt-1 text-xs text-slate-500">用于 `/api/customer/*`、网页登录取 Cookie、签到和资源解锁。</div>
+                  <div className="text-sm font-medium ui-title">启用 Browser Bridge 签名模式</div>
+                  <div className="mt-1 text-xs ui-muted">用于 `/api/customer/*`、网页登录取 Cookie、签到和资源解锁。</div>
                 </div>
                 <Switch checked={settings.hdhive.browserBridge.enabled} onChange={(v) => updateSettings('hdhive.browserBridge.enabled', v)} />
               </div>
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">API Key</label>
+              <label className="text-sm font-medium ui-title">API Key</label>
               <input
                 type="password"
                 value={settings.hdhive.apiKey}
@@ -1398,7 +1398,7 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium text-slate-700">资源解锁 Action ID</label>
+              <label className="text-sm font-medium ui-title">资源解锁 Action ID</label>
               <input
                 type="text"
                 value={settings.hdhive.resourceUnlockActionId}
@@ -1410,8 +1410,8 @@ const SettingsTab: React.FC = () => {
             <div className="space-y-3 md:col-span-2">
               <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
                 <div>
-                  <div className="text-sm font-medium text-slate-700">每日自动签到</div>
-                  <div className="mt-1 text-xs text-slate-500">依赖 Browser Bridge 签名模式，按下方 Cron 定时调用影巢签到接口并推送积分结果。</div>
+                  <div className="text-sm font-medium ui-title">每日自动签到</div>
+                  <div className="mt-1 text-xs ui-muted">依赖 Browser Bridge 签名模式，按下方 Cron 定时调用影巢签到接口并推送积分结果。</div>
                 </div>
                 <Switch checked={settings.hdhive.checkin.enabled} onChange={(v) => updateSettings('hdhive.checkin.enabled', v)} />
               </div>
@@ -1420,8 +1420,8 @@ const SettingsTab: React.FC = () => {
                   <div className="space-y-2">
                     <div className="flex w-full items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-5 py-3">
                       <div>
-                        <div className="text-sm font-medium text-slate-700">随机签到时间</div>
-                        <div className="mt-1 text-xs text-slate-500">开启后每天在时间窗口内随机一次，关闭后按固定 Cron 执行。</div>
+                        <div className="text-sm font-medium ui-title">随机签到时间</div>
+                        <div className="mt-1 text-xs ui-muted">开启后每天在时间窗口内随机一次，关闭后按固定 Cron 执行。</div>
                       </div>
                       <Switch checked={settings.hdhive.checkin.randomTimeEnabled} onChange={(v) => updateSettings('hdhive.checkin.randomTimeEnabled', v)} />
                     </div>
@@ -1429,8 +1429,8 @@ const SettingsTab: React.FC = () => {
                   <div className="flex items-end">
                     <div className="flex w-full items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-5 py-3">
                       <div>
-                        <div className="text-sm font-medium text-slate-700">自动过人机校验</div>
-                        <div className="mt-1 text-xs text-slate-500">遇到 space_captcha 时让 Bridge 浏览器侧自动验证。</div>
+                        <div className="text-sm font-medium ui-title">自动过人机校验</div>
+                        <div className="mt-1 text-xs ui-muted">遇到 space_captcha 时让 Bridge 浏览器侧自动验证。</div>
                       </div>
                       <Switch checked={settings.hdhive.checkin.autoVerify} onChange={(v) => updateSettings('hdhive.checkin.autoVerify', v)} />
                     </div>
@@ -1438,7 +1438,7 @@ const SettingsTab: React.FC = () => {
                   {settings.hdhive.checkin.randomTimeEnabled ? (
                     <>
                       <div className="space-y-2">
-                        <label className="text-sm font-medium text-slate-700">开始时间</label>
+                        <label className="text-sm font-medium ui-title">开始时间</label>
                         <input
                           type="time"
                           value={settings.hdhive.checkin.randomWindowStart}
@@ -1447,7 +1447,7 @@ const SettingsTab: React.FC = () => {
                         />
                       </div>
                       <div className="space-y-2">
-                        <label className="text-sm font-medium text-slate-700">结束时间</label>
+                        <label className="text-sm font-medium ui-title">结束时间</label>
                         <input
                           type="time"
                           value={settings.hdhive.checkin.randomWindowEnd}
@@ -1458,7 +1458,7 @@ const SettingsTab: React.FC = () => {
                     </>
                   ) : (
                     <div className="space-y-2">
-                      <label className="text-sm font-medium text-slate-700">签到 Cron</label>
+                      <label className="text-sm font-medium ui-title">签到 Cron</label>
                       <input
                         type="text"
                         value={settings.hdhive.checkin.cron}
@@ -1477,10 +1477,10 @@ const SettingsTab: React.FC = () => {
 
       {/* Custom Push Management */}
       <section id="settings-custom-push" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-custom-push')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Bell size={24} className="text-[#b3261e]" /> 自定义推送列表
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="flex justify-end">
             <button 
               type="button"
@@ -1506,8 +1506,8 @@ const SettingsTab: React.FC = () => {
                       <Bell size={20} />
                     </div>
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-slate-900 truncate">{push.name}</p>
-                      <p className="text-xs text-slate-500 truncate max-w-[300px]">{push.description || push.url}</p>
+                      <p className="text-sm font-medium ui-title truncate">{push.name}</p>
+                      <p className="text-xs ui-muted truncate max-w-[300px]">{push.description || push.url}</p>
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
@@ -1547,10 +1547,10 @@ const SettingsTab: React.FC = () => {
 
       {/* Regex Presets Management */}
       <section id="settings-regex" className="space-y-4 scroll-mt-24" hidden={visibleSectionIds != null && !visibleSectionIds.includes('settings-regex')}>
-        <h3 className="text-xl font-medium text-slate-900 flex items-center gap-3">
+        <h3 className="text-xl font-medium ui-title flex items-center gap-3">
           <Cpu size={24} className="text-[#0b57d0]" /> 正则预设列表
         </h3>
-        <div className="bg-white rounded-3xl border border-slate-200/60 p-8 space-y-6 shadow-sm">
+        <div className="ui-card p-8 space-y-6 shadow-sm">
           <div className="flex justify-end">
             <button 
               type="button"
@@ -1576,8 +1576,8 @@ const SettingsTab: React.FC = () => {
                       <Cpu size={20} />
                     </div>
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-slate-900 truncate">{preset.name}</p>
-                      <p className="text-xs text-slate-500 truncate max-w-[300px]">{preset.description || `${preset.sourceRegex} -> ${preset.targetRegex}`}</p>
+                      <p className="text-sm font-medium ui-title truncate">{preset.name}</p>
+                      <p className="text-xs ui-muted truncate max-w-[300px]">{preset.description || `${preset.sourceRegex} -> ${preset.targetRegex}`}</p>
                     </div>
                   </div>
                   <div className="flex items-center gap-2">

--- a/frontend/src/components/tabs/StrmConfigTab.tsx
+++ b/frontend/src/components/tabs/StrmConfigTab.tsx
@@ -460,7 +460,7 @@ const StrmConfigTab: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+      <div className="ui-card overflow-hidden shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50/50 border-b border-slate-100">
@@ -490,7 +490,7 @@ const StrmConfigTab: React.FC = () => {
                       <div className={`p-2 rounded-xl ${config.enabled ? 'bg-[#c2e7ff] text-[#001d35]' : 'bg-slate-100 text-slate-400'}`}>
                         <Link2 size={20} />
                       </div>
-                      <span className="font-medium text-slate-900">{config.name}</span>
+                      <span className="font-medium ui-title">{config.name}</span>
                     </div>
                   </td>
                   <td className="px-6 py-4 text-slate-600">
@@ -601,7 +601,7 @@ const StrmConfigTab: React.FC = () => {
       >
         <form onSubmit={handleSaveConfig} className="space-y-6">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">配置名称</label>
+            <label className="text-sm font-medium ui-title">配置名称</label>
             <input 
               type="text" 
               value={formData.name}
@@ -614,7 +614,7 @@ const StrmConfigTab: React.FC = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">生成类型</label>
+              <label className="text-sm font-medium ui-title">生成类型</label>
               <select 
                 value={formData.type}
                 onChange={e => setFormData({...formData, type: e.target.value as 'normal' | 'subscription'})}
@@ -625,7 +625,7 @@ const StrmConfigTab: React.FC = () => {
               </select>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">本地路径前缀 (可选)</label>
+              <label className="text-sm font-medium ui-title">本地路径前缀 (可选)</label>
               <input
                 type="text"
                 value={formData.localPathPrefix || ''}
@@ -650,7 +650,7 @@ const StrmConfigTab: React.FC = () => {
           {formData.type === 'normal' ? (
             <div className="space-y-4">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-700">选择账号</label>
+                <label className="text-sm font-medium ui-title">选择账号</label>
                 <div className="flex flex-wrap gap-3 p-4 bg-slate-50 rounded-2xl border border-slate-200">
                   {accounts.map(acc => (
                     <label key={acc.id} className="flex items-center gap-2 cursor-pointer group">
@@ -676,7 +676,7 @@ const StrmConfigTab: React.FC = () => {
 
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <label className="text-sm font-medium text-slate-700">指定目录 (可选)</label>
+                  <label className="text-sm font-medium ui-title">指定目录 (可选)</label>
                   <div className="flex items-center gap-2">
                     <select 
                       className="text-xs border border-slate-300 rounded-full px-3 py-1 bg-white outline-none"
@@ -694,14 +694,14 @@ const StrmConfigTab: React.FC = () => {
                 </div>
                 <div className="space-y-2 max-h-48 overflow-y-auto pr-2 custom-scrollbar">
                   {!formData.directories?.length ? (
-                    <p className="text-xs text-slate-500 italic p-4 text-center bg-slate-50 rounded-2xl border border-dashed border-slate-300">
+                    <p className="text-xs ui-muted italic p-4 text-center bg-slate-50 rounded-2xl border border-dashed border-slate-300">
                       未选择目录，将按账号媒体目录整体生成。
                     </p>
                   ) : (
                     formData.directories.map((dir, idx) => (
                       <div key={idx} className="flex items-center justify-between p-3 bg-white border border-slate-200 rounded-xl group hover:border-[#0b57d0]/30 transition-colors">
                         <div className="flex flex-col min-w-0">
-                          <span className="text-sm font-medium text-slate-900 truncate">{dir.name}</span>
+                          <span className="text-sm font-medium ui-title truncate">{dir.name}</span>
                           <span className="text-[10px] text-slate-500 truncate">{getAccountLabel(dir.accountId)} / {dir.path}</span>
                         </div>
                         <button 
@@ -720,7 +720,7 @@ const StrmConfigTab: React.FC = () => {
           ) : (
             <div className="space-y-4">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-700">选择订阅</label>
+                <label className="text-sm font-medium ui-title">选择订阅</label>
                 <select 
                   value={formData.subscriptionId || ''}
                   onChange={e => setFormData({...formData, subscriptionId: Number(e.target.value), resourceIds: []})}
@@ -736,7 +736,7 @@ const StrmConfigTab: React.FC = () => {
 
               {formData.subscriptionId && (
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-slate-700">选择资源 (可选)</label>
+                  <label className="text-sm font-medium ui-title">选择资源 (可选)</label>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 p-4 bg-slate-50 rounded-2xl border border-slate-200 max-h-48 overflow-y-auto custom-scrollbar">
                     {resources.map(res => (
                       <label key={res.id} className="flex items-center gap-2 cursor-pointer group">
@@ -757,7 +757,7 @@ const StrmConfigTab: React.FC = () => {
                         <span className="text-xs text-slate-600 truncate" title={res.title}>{res.title}</span>
                       </label>
                     ))}
-                    {resources.length === 0 && <p className="col-span-2 text-center text-xs text-slate-500 py-4">该订阅暂无资源</p>}
+                    {resources.length === 0 && <p className="col-span-2 text-center text-xs ui-muted py-4">该订阅暂无资源</p>}
                   </div>
                   <p className="text-[10px] text-slate-400">不勾选任何资源则生成该订阅下的所有资源。</p>
                 </div>
@@ -767,7 +767,7 @@ const StrmConfigTab: React.FC = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">排除模式 (正则, 可选)</label>
+              <label className="text-sm font-medium ui-title">排除模式 (正则, 可选)</label>
               <input
                 type="text"
                 value={formData.excludePattern || ''}
@@ -822,7 +822,7 @@ const StrmConfigTab: React.FC = () => {
 
           {formData.enableCron && (
             <div className="space-y-2 animate-in slide-in-from-top-2 duration-200">
-              <label className="text-sm font-medium text-slate-700">Cron 表达式</label>
+              <label className="text-sm font-medium ui-title">Cron 表达式</label>
               <input
                 type="text"
                 value={formData.cronExpression || ''}
@@ -864,7 +864,7 @@ const StrmConfigTab: React.FC = () => {
             </p>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">选择账号</label>
+            <label className="text-sm font-medium ui-title">选择账号</label>
             <select
               value={lazyFormData.accountId}
               onChange={e => setLazyFormData({ ...lazyFormData, accountId: e.target.value })}
@@ -879,7 +879,7 @@ const StrmConfigTab: React.FC = () => {
           </div>
 
           <div className="space-y-2">
-             <label className="text-sm font-medium text-slate-700">分享链接</label>
+             <label className="text-sm font-medium ui-title">分享链接</label>
               <div className="flex gap-3">
                 <input
                   type="text"
@@ -901,7 +901,7 @@ const StrmConfigTab: React.FC = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">保存目录</label>
+              <label className="text-sm font-medium ui-title">保存目录</label>
               <div className="flex gap-2">
                 <input
                   type="text"
@@ -921,7 +921,7 @@ const StrmConfigTab: React.FC = () => {
               </div>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">本地路径前缀 (可选)</label>
+              <label className="text-sm font-medium ui-title">本地路径前缀 (可选)</label>
               <input
                 type="text"
                 value={lazyFormData.localPathPrefix || ''}

--- a/frontend/src/components/tabs/SubscriptionTab.tsx
+++ b/frontend/src/components/tabs/SubscriptionTab.tsx
@@ -804,7 +804,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
         </button>
       </div>
       
-      <div className="bg-white rounded-3xl border border-slate-200/60 overflow-hidden shadow-sm">
+      <div className="ui-card overflow-hidden shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50/50 border-b border-slate-100">
@@ -835,12 +835,12 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                         <Rss size={20} />
                       </div>
                       <div className="flex flex-col">
-                        <span className="font-medium text-slate-900 truncate max-w-[150px]" title={sub.name}>{sub.name}</span>
+                        <span className="font-medium ui-title truncate max-w-[150px]" title={sub.name}>{sub.name}</span>
                         {!sub.enabled && <span className="text-[10px] text-red-500 font-bold uppercase">已禁用</span>}
                       </div>
                     </div>
                   </td>
-                  <td className="px-6 py-4 font-mono text-xs text-slate-500">{sub.uuid}</td>
+                  <td className="px-6 py-4 font-mono text-xs ui-muted">{sub.uuid}</td>
                   <td className="px-6 py-4 text-slate-600">{sub.resourceCount}</td>
                   <td className="px-6 py-4">
                     <div className="flex items-center gap-1.5" title={sub.lastRefreshMessage || ''}>
@@ -897,7 +897,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
       >
         <form id="modal-form" onSubmit={handleSaveSub} className="space-y-6">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">UUID / 订阅主页链接</label>
+            <label className="text-sm font-medium ui-title">UUID / 订阅主页链接</label>
             <input 
               type="text" 
               value={subFormData.uuid}
@@ -957,8 +957,8 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
               <div className="mt-3 p-4 bg-[#f8fbff] rounded-2xl border border-[#d7e7ff] space-y-3">
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <div className="text-sm font-medium text-slate-900">订阅内链接选择</div>
-                    <div className="text-xs text-slate-500 mt-1">
+                    <div className="text-sm font-medium ui-title">订阅内链接选择</div>
+                    <div className="text-xs ui-muted mt-1">
                       当前已选 {subFormData.selectedShareCodes.length} 项，未选择时默认全量同步。
                     </div>
                   </div>
@@ -1001,7 +1001,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
             )}
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">名称 (可选)</label>
+            <label className="text-sm font-medium ui-title">名称 (可选)</label>
             <input 
               type="text" 
               value={subFormData.name}
@@ -1011,7 +1011,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">备注</label>
+            <label className="text-sm font-medium ui-title">备注</label>
             <textarea 
               value={subFormData.remark}
               onChange={e => setSubFormData({...subFormData, remark: e.target.value})}
@@ -1044,8 +1044,8 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                 <div className="rounded-2xl border border-[#d7e7ff] bg-[#f8fbff] p-4 space-y-3">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <div className="text-sm font-medium text-slate-900">任务预估</div>
-                      <div className="text-xs text-slate-500 mt-1">
+                      <div className="text-sm font-medium ui-title">任务预估</div>
+                      <div className="text-xs ui-muted mt-1">
                         默认账号和保存目录沿用“自动追剧”设置，任务分组默认单独归到订阅任务。
                       </div>
                     </div>
@@ -1056,19 +1056,19 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
                     <div className="rounded-xl bg-white border border-slate-200 px-3 py-2">
                       <div className="text-slate-500">默认账号</div>
-                      <div className="mt-1 font-medium text-slate-900">
+                      <div className="mt-1 font-medium ui-title">
                         {subFormData.autoTaskConfig.accountId || '未配置'}
                       </div>
                     </div>
                     <div className="rounded-xl bg-white border border-slate-200 px-3 py-2">
                       <div className="text-slate-500">默认保存目录</div>
-                      <div className="mt-1 font-medium text-slate-900 truncate" title={subFormData.autoTaskConfig.targetFolder || ''}>
+                      <div className="mt-1 font-medium ui-title truncate" title={subFormData.autoTaskConfig.targetFolder || ''}>
                         {subFormData.autoTaskConfig.targetFolder || '未配置'}
                       </div>
                     </div>
                     <div className="rounded-xl bg-white border border-slate-200 px-3 py-2">
                       <div className="text-slate-500">订阅资源数</div>
-                      <div className="mt-1 font-medium text-slate-900">
+                      <div className="mt-1 font-medium ui-title">
                         {autoTaskPreview?.estimatedResourceCount ?? previewInfo?.remoteResourceCount ?? 0}
                       </div>
                     </div>
@@ -1097,7 +1097,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <label className="text-sm font-medium text-slate-700">任务分组</label>
+                    <label className="text-sm font-medium ui-title">任务分组</label>
                     <input
                       type="text"
                       value={subFormData.autoTaskConfig.taskGroup}
@@ -1107,7 +1107,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                     />
                   </div>
                   <div className="space-y-2">
-                    <label className="text-sm font-medium text-slate-700">任务备注</label>
+                    <label className="text-sm font-medium ui-title">任务备注</label>
                     <input
                       type="text"
                       value={subFormData.autoTaskConfig.remark}
@@ -1147,7 +1147,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
 
                 {subFormData.autoTaskConfig.enableCron && (
                   <div className="space-y-2">
-                    <label className="text-sm font-medium text-slate-700">Cron 表达式</label>
+                    <label className="text-sm font-medium ui-title">Cron 表达式</label>
                     <input
                       type="text"
                       value={subFormData.autoTaskConfig.cronExpression}
@@ -1174,7 +1174,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
         title="选择订阅里的链接"
         footer={
           <div className="px-8 py-6 flex justify-between gap-3 border-t border-slate-100">
-            <div className="text-xs text-slate-500 self-center">
+            <div className="text-xs ui-muted self-center">
               已选 {remoteSelectorSelectedShareCodes.length} 项
             </div>
             <div className="flex gap-3">
@@ -1196,7 +1196,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
       >
         <div className="space-y-4 pt-6">
           <div className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3 text-xs text-slate-600">
-            <div className="font-medium text-slate-900">UUID</div>
+            <div className="font-medium ui-title">UUID</div>
             <div className="mt-1 font-mono break-all">{remoteSelectorUuid || subFormData.uuid || '-'}</div>
             <div className="mt-2 text-slate-500">
               保存后仅同步勾选的链接；如果不勾选，则仍按整个订阅全量同步。
@@ -1234,7 +1234,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
             </button>
           </div>
 
-          <div className="flex items-center justify-between text-xs text-slate-500">
+          <div className="flex items-center justify-between text-xs ui-muted">
             <span>远程共 {remoteSelectorTotalCount} 项</span>
             <span>第 {remoteSelectorPageNum} / {Math.max(remoteSelectorTotalPages, 1)} 页</span>
           </div>
@@ -1270,7 +1270,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex flex-col gap-1">
-                        <span className="font-medium text-slate-900 break-all">{item.title}</span>
+                        <span className="font-medium ui-title break-all">{item.title}</span>
                         <a
                           href={item.shareLink}
                           target="_blank"
@@ -1368,7 +1368,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                 <tr key={res.id} className="hover:bg-slate-50/50 transition-colors">
                   <td className="px-4 py-3">
                     <div className="flex flex-col max-w-[200px]">
-                      <span className="font-medium text-slate-900 truncate" title={res.title}>{res.title}</span>
+                      <span className="font-medium ui-title truncate" title={res.title}>{res.title}</span>
                       <a 
                         href={res.shareLink} 
                         target="_blank" 
@@ -1442,7 +1442,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
       >
         <form id="res-modal-form" onSubmit={handleSaveResource} className="space-y-6">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">资源标题 (可选)</label>
+            <label className="text-sm font-medium ui-title">资源标题 (可选)</label>
             <input 
               type="text" 
               value={resFormData.title}
@@ -1452,7 +1452,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">分享链接</label>
+            <label className="text-sm font-medium ui-title">分享链接</label>
             <input 
               type="text" 
               value={resFormData.shareLink}
@@ -1463,7 +1463,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-700">访问码 (可选)</label>
+            <label className="text-sm font-medium ui-title">访问码 (可选)</label>
             <input 
               type="text" 
               value={resFormData.accessCode}
@@ -1497,7 +1497,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
         footer={null}
       >
         <div className="space-y-4">
-          <div className="flex items-center gap-2 p-2 bg-slate-50 rounded-2xl overflow-x-auto text-xs text-slate-500 whitespace-nowrap scrollbar-none">
+          <div className="flex items-center gap-2 p-2 bg-slate-50 rounded-2xl overflow-x-auto text-xs ui-muted whitespace-nowrap scrollbar-none">
             <span className="shrink-0">{browserTitle}</span>
             {browserStack.map((folder, i) => (
               <React.Fragment key={folder.id}>
@@ -1562,7 +1562,7 @@ const SubscriptionTab: React.FC<SubscriptionTabProps> = ({ onTransfer }) => {
                   </tr>
                 ) : browserEntries.map(entry => (
                   <tr key={entry.id} className="hover:bg-slate-50/50 transition-colors">
-                    <td className="px-4 py-3 font-medium text-slate-900 truncate max-w-[200px]" title={entry.name}>{entry.name}</td>
+                    <td className="px-4 py-3 font-medium ui-title truncate max-w-[200px]" title={entry.name}>{entry.name}</td>
                     <td className="px-4 py-3 text-slate-500 text-xs">{entry.isFolder ? '目录' : '文件'}</td>
                     <td className="px-4 py-3 text-right">
                       <div className="flex items-center justify-end gap-2">

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -140,7 +140,13 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
         setTotalPages(nextTotalPages);
         // 仅丢弃不在当前页结果里的选中项；不要整表清空（否则全选会被随后的刷新冲掉）
         const nextIds = new Set(nextTasks.map((task) => task.id));
-        setSelectedTaskIds((prev) => prev.filter((id) => nextIds.has(id)));
+        setSelectedTaskIds((prev) => {
+          const next = prev.filter((id) => nextIds.has(id));
+          if (next.length === prev.length && next.every((id, i) => id === prev[i])) {
+            return prev;
+          }
+          return next;
+        });
         if (page > nextTotalPages) {
           setPage(nextTotalPages);
         }
@@ -253,10 +259,20 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const pageStart = totalTasks === 0 ? 0 : (page - 1) * TASK_PAGE_SIZE + 1;
   const pageEnd = Math.min(page * TASK_PAGE_SIZE, totalTasks);
 
+  // 仅在 filter 选项变化时修剪失效标签；内容不变时必须返回原数组，否则会触发 fetch 死循环
   useEffect(() => {
-    const availableTagKeys = new Set(availableTagFilters.map((filterTag) => filterTag.key));
-    setActiveTagFilters((currentFilters) => currentFilters.filter((filterKey) => availableTagKeys.has(filterKey)));
-  }, [tasks]);
+    const availableTagKeys = new Set([
+      ...TASK_FEATURE_FILTERS.map((filterTag) => filterTag.key),
+      ...filterGroups.map((group) => `group:${group}`),
+    ]);
+    setActiveTagFilters((currentFilters) => {
+      const next = currentFilters.filter((filterKey) => availableTagKeys.has(filterKey));
+      if (next.length === currentFilters.length && next.every((key, i) => key === currentFilters[i])) {
+        return currentFilters;
+      }
+      return next;
+    });
+  }, [filterGroups]);
 
   const handleExecuteTask = async (id: number) => {
     if (executingTaskIds.includes(id)) {

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -77,23 +77,6 @@ const TASK_FEATURE_FILTERS: Array<{
   { key: 'feature:keep-cas', label: '保留CAS', matches: (task) => Boolean(task.keepCasAfterRestore) }
 ];
 
-const getTaskFilterKeys = (task: Task) => {
-  const filterKeys: string[] = [];
-  const groupName = task.taskGroup?.trim();
-
-  if (groupName) {
-    filterKeys.push(`group:${groupName}`);
-  }
-
-  TASK_FEATURE_FILTERS.forEach((filterTag) => {
-    if (filterTag.matches(task)) {
-      filterKeys.push(filterTag.key);
-    }
-  });
-
-  return filterKeys;
-};
-
 const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const toast = useToast();
   const dialog = useDialog();
@@ -118,6 +101,8 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
 
+  const [filterGroups, setFilterGroups] = useState<string[]>([]);
+
   const fetchTasks = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     try {
@@ -128,6 +113,21 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       });
       if (debouncedSearchTerm) {
         params.set('search', debouncedSearchTerm);
+      }
+      const featureKeys = activeTagFilters
+        .filter((key) => key.startsWith('feature:'))
+        .map((key) => key.slice('feature:'.length));
+      const groupKeys = activeTagFilters
+        .filter((key) => key.startsWith('group:'))
+        .map((key) => key.slice('group:'.length));
+      if (featureKeys.length > 0) {
+        params.set('features', featureKeys.join(','));
+      }
+      // 多分组时取第一个精确匹配（UI 芯片为 AND；多 group 罕见，用 search 补）
+      if (groupKeys.length === 1) {
+        params.set('taskGroup', groupKeys[0]);
+      } else if (groupKeys.length > 1) {
+        params.set('taskGroup', groupKeys[0]);
       }
       const response = await fetch(`/api/tasks?${params.toString()}`, { signal });
       const data = await response.json();
@@ -152,7 +152,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
         setLoading(false);
       }
     }
-  }, [statusFilter, debouncedSearchTerm, page]);
+  }, [statusFilter, debouncedSearchTerm, page, activeTagFilters]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -163,13 +163,31 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
 
   useEffect(() => {
     setPage(1);
-  }, [statusFilter, debouncedSearchTerm]);
+  }, [statusFilter, debouncedSearchTerm, activeTagFilters]);
 
   useEffect(() => {
     const controller = new AbortController();
     fetchTasks(controller.signal);
     return () => controller.abort();
   }, [fetchTasks]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/tasks/filter-options');
+        const data = await res.json();
+        if (!cancelled && data.success) {
+          setFilterGroups(Array.isArray(data.data?.groups) ? data.data.groups : []);
+        }
+      } catch {
+        // ignore — chips 仍可用固定 feature
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
@@ -209,37 +227,22 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
     }
   }, [openTaskMenuId]);
 
+  // feature 固定展示；group 来自全库 filter-options（不再仅当前页）
   const availableTagFilters: TaskFilterTag[] = [
-    ...TASK_FEATURE_FILTERS
-      .filter((filterTag) => tasks.some((task) => filterTag.matches(task)))
-      .map((filterTag) => ({
-        key: filterTag.key,
-        label: filterTag.label,
-        tone: 'feature' as const
-      })),
-    ...Array.from(
-      new Set(
-        tasks
-          .map((task) => task.taskGroup?.trim())
-          .filter((taskGroup): taskGroup is string => Boolean(taskGroup))
-      )
-    )
-      .sort((left, right) => left.localeCompare(right, 'zh-CN'))
-      .map((taskGroup) => ({
-        key: `group:${taskGroup}`,
-        label: taskGroup,
-        tone: 'group' as const
-      }))
+    ...TASK_FEATURE_FILTERS.map((filterTag) => ({
+      key: filterTag.key,
+      label: filterTag.label,
+      tone: 'feature' as const
+    })),
+    ...filterGroups.map((taskGroup) => ({
+      key: `group:${taskGroup}`,
+      label: taskGroup,
+      tone: 'group' as const
+    }))
   ];
 
-  const filteredTasks = tasks.filter((task) => {
-    if (activeTagFilters.length === 0) {
-      return true;
-    }
-
-    const taskFilterKeys = new Set(getTaskFilterKeys(task));
-    return activeTagFilters.every((filterKey) => taskFilterKeys.has(filterKey));
-  });
+  // 服务端已按标签筛选，列表直接用 tasks
+  const filteredTasks = tasks;
 
   const allVisibleSelected =
     filteredTasks.length > 0 &&

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -132,12 +132,15 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       const response = await fetch(`/api/tasks?${params.toString()}`, { signal });
       const data = await response.json();
       if (data.success) {
-        setTasks(data.data || []);
+        const nextTasks: Task[] = data.data || [];
+        setTasks(nextTasks);
         const nextTotal = Number(data.pagination?.total || 0);
         const nextTotalPages = Math.max(1, Number(data.pagination?.totalPages || 1));
         setTotalTasks(nextTotal);
         setTotalPages(nextTotalPages);
-        setSelectedTaskIds([]);
+        // 仅丢弃不在当前页结果里的选中项；不要整表清空（否则全选会被随后的刷新冲掉）
+        const nextIds = new Set(nextTasks.map((task) => task.id));
+        setSelectedTaskIds((prev) => prev.filter((id) => nextIds.has(id)));
         if (page > nextTotalPages) {
           setPage(nextTotalPages);
         }

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -763,11 +763,11 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
           </span>
         </label>
 
-        <span className="text-sm text-slate-500">
+        <span className="text-sm ui-muted">
           已选 {selectedTaskIds.length} 项
         </span>
 
-        <span className="text-sm text-slate-500">
+        <span className="text-sm ui-muted">
           显示 {pageStart}-{pageEnd} / {totalTasks} 项
         </span>
 
@@ -891,14 +891,14 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
                   </div>
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="font-bold text-slate-900 text-lg truncate max-w-[300px]" title={taskName}>{taskName}</h3>
+                      <h3 className="font-bold ui-title text-lg truncate max-w-[300px]" title={taskName}>{taskName}</h3>
                       {getStatusBadge(task.status)}
                       {task.enableLazyStrm && <span className="px-2 py-0.5 bg-amber-100 text-amber-700 rounded text-[10px] font-bold">懒STRM</span>}
                       {task.enableCron && <span className="px-2 py-0.5 bg-violet-100 text-violet-700 rounded text-[10px] font-bold">定时任务</span>}
                       {task.enableOrganizer && <span className="px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded text-[10px] font-bold">整理器</span>}
                       {task.keepCasAfterRestore && <span className="px-2 py-0.5 bg-sky-100 text-sky-700 rounded text-[10px] font-bold">保留CAS</span>}
                     </div>
-                    <p className="text-sm text-slate-500 mt-1">
+                    <p className="text-sm ui-muted mt-1">
                       账号: {task.account?.username || '未知账号'} • 分组: {task.taskGroup || '-'}
                     </p>
                     <div className="flex items-center gap-4 mt-3">
@@ -913,7 +913,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
                 
                 <div className="flex flex-col items-end gap-3">
                   <div className="text-right">
-                    <div className="text-sm font-bold text-slate-900">{task.currentEpisodes} / {task.totalEpisodes > 0 ? task.totalEpisodes : '?'} 集</div>
+                    <div className="text-sm font-bold ui-title">{task.currentEpisodes} / {task.totalEpisodes > 0 ? task.totalEpisodes : '?'} 集</div>
                     <div className="w-36 h-2 bg-slate-100 rounded-full mt-2 overflow-hidden">
                       <motion.div 
                         initial={{ width: 0 }}
@@ -996,7 +996,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
         {filteredTasks.length === 0 && !loading && (
           <div className="text-center py-20 bg-slate-50 rounded-3xl border border-dashed border-slate-300">
             <ClipboardList size={48} className="mx-auto text-slate-300 mb-4" />
-            <p className="text-slate-500 font-medium">
+            <p className="ui-muted font-medium">
               {tasks.length === 0 ? '暂无任务' : '没有匹配当前筛选条件的任务'}
             </p>
           </div>
@@ -1005,7 +1005,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
 
       {totalPages > 1 && (
         <div className="flex flex-col items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm sm:flex-row">
-          <span className="text-sm text-slate-500">
+          <span className="text-sm ui-muted">
             第 {page} / {totalPages} 页，每页 {TASK_PAGE_SIZE} 项
           </span>
           <div className="flex items-center gap-2">
@@ -1013,7 +1013,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
               type="button"
               onClick={() => setPage((currentPage) => Math.max(1, currentPage - 1))}
               disabled={page <= 1 || loading}
-              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium ui-title transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               上一页
             </button>
@@ -1021,7 +1021,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
               type="button"
               onClick={() => setPage((currentPage) => Math.min(totalPages, currentPage + 1))}
               disabled={page >= totalPages || loading}
-              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium ui-title transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               下一页
             </button>

--- a/frontend/src/components/ui/SettingsNav.tsx
+++ b/frontend/src/components/ui/SettingsNav.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+
+export interface SettingsNavItem {
+  id: string;
+  label: string;
+  /** 额外匹配关键词（过滤用） */
+  keywords?: string[];
+}
+
+interface SettingsNavProps {
+  items: SettingsNavItem[];
+  /** 过滤变化时回传可见 id 列表，父级用来隐藏 section */
+  onVisibleChange?: (visibleIds: string[]) => void;
+  className?: string;
+}
+
+const SettingsNav: React.FC<SettingsNavProps> = ({ items, onVisibleChange, className = '' }) => {
+  const [query, setQuery] = useState('');
+
+  const visibleItems = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((item) => {
+      const hay = [item.label, ...(item.keywords || [])].join(' ').toLowerCase();
+      return hay.includes(q);
+    });
+  }, [items, query]);
+
+  React.useEffect(() => {
+    onVisibleChange?.(visibleItems.map((i) => i.id));
+  }, [visibleItems, onVisibleChange]);
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-secondary)]" size={16} />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="过滤分区…"
+          className="w-full pl-10 pr-4 py-2.5 bg-[var(--bg-main)] border border-[var(--border-color)] rounded-full text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20 text-[var(--text-primary)]"
+        />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {visibleItems.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => scrollTo(item.id)}
+            className="px-3 py-1.5 rounded-full text-xs font-medium border border-[var(--border-color)] bg-[var(--bg-main)] text-[var(--text-primary)] hover:bg-[#d3e3fd]/60 hover:border-[#0b57d0]/40 dark:hover:bg-[#0b57d0]/20 transition-colors"
+          >
+            {item.label}
+          </button>
+        ))}
+        {visibleItems.length === 0 && (
+          <span className="text-xs text-[var(--text-secondary)] py-1">无匹配分区</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsNav;
+
+/** 滚动到 section；用于跨 Tab 跳转 */
+export function scrollToSettingsSection(id: string, retries = 12) {
+  const tryScroll = (left: number) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      return;
+    }
+    if (left > 0) {
+      requestAnimationFrame(() => tryScroll(left - 1));
+    }
+  };
+  // 等 Tab 挂载
+  setTimeout(() => tryScroll(retries), 50);
+}
+
+export const MEDIA_SECTION_STORAGE_KEY = 'media-scroll-section';

--- a/frontend/src/components/ui/SettingsNav.tsx
+++ b/frontend/src/components/ui/SettingsNav.tsx
@@ -70,20 +70,27 @@ const SettingsNav: React.FC<SettingsNavProps> = ({ items, onVisibleChange, class
 
 export default SettingsNav;
 
-/** 滚动到 section；用于跨 Tab 跳转 */
-export function scrollToSettingsSection(id: string, retries = 12) {
+/** 滚动到 section；用于跨 Tab 跳转（等 Tab 动画/数据挂载） */
+export function scrollToSettingsSection(id: string, retries = 40) {
   const tryScroll = (left: number) => {
     const el = document.getElementById(id);
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // 主滚动容器优先；没有则退回元素自身
+      const scroller = document.querySelector('.content-scrollable') as HTMLElement | null;
+      if (scroller) {
+        const top = el.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop - 16;
+        scroller.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+      } else {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
       return;
     }
     if (left > 0) {
-      requestAnimationFrame(() => tryScroll(left - 1));
+      window.setTimeout(() => tryScroll(left - 1), 50);
     }
   };
-  // 等 Tab 挂载
-  setTimeout(() => tryScroll(retries), 50);
+  // Tab 切换有 ~200ms 动画，略等再找节点
+  window.setTimeout(() => tryScroll(retries), 220);
 }
 
 export const MEDIA_SECTION_STORAGE_KEY = 'media-scroll-section';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,11 @@
+/* 国内环境可选加载；失败则回退 system-ui（见 --font-sans） */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Flex:opsz,wght@8..144,400;500;700&display=swap');
 @import "tailwindcss";
 
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --font-sans: "Inter", "Roboto Flex", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", "Roboto Flex", ui-sans-serif, system-ui, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
   --color-brand: #0b57d0;
   --color-brand-container: #d3e3fd;
   --color-brand-container-hover: #c2e7ff;
@@ -45,6 +46,41 @@
 
   body {
     @apply bg-[var(--bg-surface)] text-[var(--text-primary)] antialiased transition-colors duration-300;
+  }
+}
+
+/* 语义表面：优先用这些，逐步替代硬编码 bg-white / text-slate-*
+ * 一期仍保留下方 .dark !important 兼容层，后续可删 */
+@layer components {
+  .ui-card {
+    background-color: var(--bg-main);
+    border: 1px solid var(--border-color);
+    border-radius: 1.5rem; /* rounded-3xl */
+  }
+
+  .ui-card-muted {
+    background-color: color-mix(in srgb, var(--bg-surface) 80%, var(--bg-main));
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+  }
+
+  .ui-title {
+    color: var(--text-primary);
+  }
+
+  .ui-muted {
+    color: var(--text-secondary);
+  }
+
+  .ui-input {
+    background-color: color-mix(in srgb, var(--bg-surface) 70%, var(--bg-main));
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+  }
+
+  .ui-input::placeholder {
+    color: var(--text-secondary);
+    opacity: 0.85;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1490,21 +1490,34 @@ AppDataSource.initialize().then(async () => {
         }
     });
     // 任务相关API
-    app.get('/api/tasks', async (req, res) => {
-        const { status } = req.query;
-        const search = String(req.query.search || '').trim().slice(0, 100);
-        const shouldPaginate = req.query.page != null || req.query.pageSize != null || req.query.limit != null;
-        const page = parsePaginationInt(req.query.page, 1, Number.MAX_SAFE_INTEGER);
-        const pageSize = parsePaginationInt(req.query.pageSize || req.query.limit, 50, 200);
-        let whereClause = { }; // 用于构建最终的 where 条件
+    // feature 标签 → Task 布尔字段（与前端 TASK_FEATURE_FILTERS 对齐）
+    const TASK_FEATURE_FIELD_MAP = {
+        'lazy-strm': 'enableLazyStrm',
+        'cron': 'enableCron',
+        'organizer': 'enableOrganizer',
+        'keep-cas': 'keepCasAfterRestore'
+    };
 
-        // 基础条件（AND）
+    const buildTaskListWhere = ({ status, search, features, taskGroup }) => {
+        let whereClause = {};
         if (status && status !== 'all') {
             whereClause.status = status;
         }
         whereClause.enableSystemProxy = Or(IsNull(), false);
 
-        // 添加搜索过滤
+        const featureList = Array.isArray(features) ? features : [];
+        for (const feature of featureList) {
+            const field = TASK_FEATURE_FIELD_MAP[feature];
+            if (field) {
+                whereClause[field] = true;
+            }
+        }
+
+        const groupName = String(taskGroup || '').trim();
+        if (groupName) {
+            whereClause.taskGroup = groupName;
+        }
+
         if (search) {
             const searchConditions = [
                 { resourceName: Like(`%${search}%`) },
@@ -1515,14 +1528,30 @@ AppDataSource.initialize().then(async () => {
                 { account: { username: Like(`%${search}%`) } }
             ];
             if (Object.keys(whereClause).length > 0) {
-                whereClause = searchConditions.map(searchCond => ({
-                    ...whereClause, // 包含基础条件 (如 status)
-                    ...searchCond   // 包含一个搜索条件
+                whereClause = searchConditions.map((searchCond) => ({
+                    ...whereClause,
+                    ...searchCond
                 }));
-            }else{
+            } else {
                 whereClause = searchConditions;
             }
         }
+        return whereClause;
+    };
+
+    app.get('/api/tasks', async (req, res) => {
+        const { status } = req.query;
+        const search = String(req.query.search || '').trim().slice(0, 100);
+        const taskGroup = String(req.query.taskGroup || '').trim().slice(0, 100);
+        const features = String(req.query.features || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        const shouldPaginate = req.query.page != null || req.query.pageSize != null || req.query.limit != null;
+        const page = parsePaginationInt(req.query.page, 1, Number.MAX_SAFE_INTEGER);
+        const pageSize = parsePaginationInt(req.query.pageSize || req.query.limit, 50, 200);
+        const whereClause = buildTaskListWhere({ status, search, features, taskGroup });
+
         const findOptions = {
             order: { id: 'DESC' },
             relations: {
@@ -1565,6 +1594,31 @@ AppDataSource.initialize().then(async () => {
                 }
             } : {})
         });
+    });
+
+    // 标签芯片：固定 feature + 全库出现过的 taskGroup（不受分页限制）
+    app.get('/api/tasks/filter-options', async (req, res) => {
+        try {
+            const rows = await taskRepo
+                .createQueryBuilder('task')
+                .select('DISTINCT task.taskGroup', 'taskGroup')
+                .where("task.taskGroup IS NOT NULL AND task.taskGroup != ''")
+                .andWhere('(task.enableSystemProxy IS NULL OR task.enableSystemProxy = 0)')
+                .orderBy('task.taskGroup', 'ASC')
+                .getRawMany();
+            const groups = rows
+                .map((r) => String(r.taskGroup || '').trim())
+                .filter(Boolean);
+            res.json({
+                success: true,
+                data: {
+                    features: Object.keys(TASK_FEATURE_FIELD_MAP),
+                    groups
+                }
+            });
+        } catch (error) {
+            res.status(500).json({ success: false, error: error.message });
+        }
     });
 
     app.get('/api/organizer/tasks', async (req, res) => {


### PR DESCRIPTION
## Summary
在已合入的 #35–#37 之上，补齐设置长页导航、任务标签服务端筛选、暗色语义 token，以及实测修到的交互问题。

**本 PR 分支 `ui/dark-tokens` 包含尚未进 master 的全部 5 个提交**（含中间分支内容）。可直接合本 PR，不必再串 #38/#39。

## 功能
1. **Settings/Media 分区导航**
   - `SettingsNav` 分区 chip + 过滤 + 滚动
   - section 稳定 id（含 `media-cas`）
   - CAS「秒传设置」→ 媒体页秒传区块（loading 后再滚，对齐 content-scrollable）
2. **任务标签服务端筛选**
   - `GET /api/tasks?features=&taskGroup=`
   - `GET /api/tasks/filter-options`
   - 去掉页内二次 filter，分页 total 可信
3. **暗色 token**
   - `.ui-card` / `.ui-title` / `.ui-muted` / `.ui-input`
   - 主 Tab 高频卡片替换（保留 !important 兼容层一期）

## 交互修复（合前实测）
- 任务全选后被 `fetchTasks` 清空 → 只修剪失效 id
- 刷新图标死循环（`setActiveTagFilters` 总返回新数组）→ 引用相等短路
- CAS 跳转秒传锚点滚不准 → 等 Media loading 结束 + 滚主内容容器

## Test plan
- [ ] 系统/媒体页：分区 chip 跳转、过滤分区
- [ ] 秒传页点「秒传设置」→ 媒体页并滚到「秒传设置」
- [ ] 任务：勾选标签后翻页 total 正确；全选可保持；刷新图标不一直转
- [ ] 暗色：主卡片非死白底
- [ ] `npm run lint`（frontend tsc）

## Commits
```
e09503c fix(ui): 打断任务页刷新图标死循环
7dfb23d fix(ui): 任务全选被刷新清空；CAS 跳转秒传锚点更稳
60b2456 feat(ui): 暗色语义 token 与高频卡片替换
6ae7585 feat(tasks): 标签筛选下沉服务端，分页 total 可信
920baeb feat(ui): Settings/Media 分区导航与 CAS 跳转锚点
```

## 相关
- 已合：#35 滚动锁/Modal · #36 危险确认 · #37 表单正确性
- 叠放中间 PR #38 / #39 内容已包含在本 PR 中，合本 PR 后可关闭 #38 #39