### PR TITLE
fix(pt): 统一 TMDB 媒体目录与文件标题

### DIFF
--- a/src/services/ptRename.js
+++ b/src/services/ptRename.js
@@ -214,7 +214,8 @@ class PtRenameService {
             : (ConfigService.getConfigValue('openai.rename.template') || '{name} - {se}{ext}');
 
         // 标题与年份
-        const title = (aiBase && aiBase.name) || subscription.name || '未知';
+        // 目录和文件必须使用同一个标准标题，避免 TMDB 中文目录下混入 AI 提取的英文文件名。
+        const title = optionalLibraryInfo?.canonicalTitle || (aiBase && aiBase.name) || subscription.name || '未知';
         const year = (aiBase && Number(aiBase.year) > 0) ? Number(aiBase.year) : '';
         const resourceFolderName = optionalLibraryInfo?.resourceFolderName || (year ? `${title} (${year})` : title);
 

--- a/test/ptRename.test.js
+++ b/test/ptRename.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { PtRenameService } = require('../src/services/ptRename');
+
+test('AI organized path uses TMDB canonical title for both directory and file', () => {
+    const service = new PtRenameService();
+    const result = service.organizePathByAi(
+        { name: '二十世纪电气目录 - 喵萌奶茶屋' },
+        { title: '[Nekomoe kissaten][20 Seiki Denki Mokuroku][04][1080p]' },
+        { name: '[Nekomoe kissaten][20 Seiki Denki Mokuroku][04].mp4' },
+        {},
+        { name: '20 Seiki Denki Mokuroku', year: 2026, type: 'tv', season: '01' },
+        { name: '20 Seiki Denki Mokuroku', season: '01', episode: '04', extension: '.mp4' },
+        '动漫',
+        {
+            categoryName: '动漫',
+            canonicalTitle: '二十世纪电气目录',
+            resourceFolderName: '二十世纪电气目录 (2026)'
+        }
+    );
+
+    assert.deepEqual(result, {
+        dirName: '动漫/二十世纪电气目录 (2026)/Season 01',
+        fileName: '二十世纪电气目录 - S01E04.strm'
+    });
+});
+
+test('AI organized path keeps the AI title when TMDB metadata is unavailable', () => {
+    const service = new PtRenameService();
+    const result = service.organizePathByAi(
+        { name: 'Fallback subscription' },
+        { title: 'Fallback release' },
+        { name: 'Fallback.Show.S02E03.mkv' },
+        {},
+        { name: 'Fallback Show', year: 2025, type: 'tv', season: '02' },
+        { name: 'Fallback Show', season: '02', episode: '03', extension: '.mkv' }
+    );
+
+    assert.deepEqual(result, {
+        dirName: '电视剧/Fallback Show (2025)/Season 02',
+        fileName: 'Fallback Show - S02E03.strm'
+    });
+});
+
+test('AI organized movie uses the canonical title without adding a second year', () => {
+    const service = new PtRenameService();
+    const result = service.organizePathByAi(
+        { name: 'Movie subscription' },
+        { title: 'Movie release' },
+        { name: 'Original.Movie.2024.mkv' },
+        {},
+        { name: 'Original Movie', year: 2024, type: 'movie' },
+        { name: 'Original Movie', extension: '.mkv' },
+        '电影',
+        {
+            categoryName: '电影',
+            canonicalTitle: '标准电影名',
+            resourceFolderName: '标准电影名 (2024)'
+        }
+    );
+
+    assert.deepEqual(result, {
+        dirName: '电影/标准电影名 (2024)',
+        fileName: '标准电影名 (2024).strm'
+    });
+});


### PR DESCRIPTION
## 修改内容

- PT AI 整理命中 TMDB 后，文件名与媒体目录统一使用 `canonicalTitle`
- TMDB 不可用时继续回退 AI 标题，不改变原有行为
- 增加剧集、无 TMDB 回退和电影命名测试

## 问题表现

此前 TMDB 中文标题只用于目录，文件名仍使用 AI 提取的英文标题，可能出现 `动漫/二十世纪电气目录 (2026)/20 Seiki Denki Mokuroku - S01E01` 这类中英文不一致路径。

## 验证

- `node --test test/*.test.js`
- `npm run build`