### PR TITLE
feat(tg): 将机器人功能改为按钮交互

### DIFF
--- a/src/services/telegramBot/constants.js
+++ b/src/services/telegramBot/constants.js
@@ -15,13 +15,21 @@ const CB = {
     TASK_DETAIL: 'td',         // 任务详情
     TASK_RETRY: 'tr',          // 重试任务
     TASK_EXECUTE: 'te',        // 执行任务
+    TASK_STRM: 'ts',           // 生成 STRM
+    TASK_EMBY: 'em',           // 通知 Emby
+    TASK_LOGS: 'tl',           // 查看任务日志
     STATS_REFRESH: 'sr',       // 刷新统计
     HELP_NAV: 'hn',            // help 快捷导航
+    MAIN_MENU: 'mm',           // 主菜单功能入口
+    SEARCH_RESULT: 'cr',       // CloudSaver 搜索结果
+    FOLDER_DELETE: 'fx',       // 删除常用目录
     SUBS_PAGE: 'sp',           // 订阅分页
     SILENT_MODE: 'sm',         // 静默模式
     PT_SEARCH_SITE: 'ps',      // PT 搜索选择站点
     PT_SEARCH_GROUP: 'pg',     // PT 搜索选择字幕组
+    PT_SEARCH_RESULT: 'pi',    // PT 搜索结果
     PT_SUB_PAGE: 'pp',         // PT 订阅列表分页
+    PT_SUB_DETAIL: 'pv',       // PT 订阅详情
     PT_RELEASE_PAGE: 'pr',     // PT Release 列表分页
     PT_SUB_TOGGLE: 'pt',       // PT 订阅启用/禁用
     PT_SUB_REFRESH: 'px',      // PT 订阅刷新

--- a/src/services/telegramBot/core.js
+++ b/src/services/telegramBot/core.js
@@ -94,23 +94,7 @@ class TelegramBotService {
         // 设置命令菜单
         await this.bot.setMyCommands([
             { command: 'start', description: '首次使用引导' },
-            { command: 'help', description: '帮助信息' },
-            { command: 'search_cs', description: '搜索CloudSaver资源' },
-            { command: 'hdhive', description: '搜索影巢资源' },
-            { command: 'hdhive_checkin', description: '影巢签到' },
-            { command: 'pt_search', description: '搜索PT站点资源' },
-            { command: 'series', description: '自动追剧(正常任务)' },
-            { command: 'lazy_series', description: '自动追剧(懒转存STRM)' },
-            { command: 'accounts', description: '账号列表' },
-            { command: 'tasks', description: '任务列表' },
-            { command: 'execute_all', description: '执行所有任务' },
-            { command: 'fl', description: '常用目录列表' },
-            { command: 'fs', description: '添加常用目录' },
-            { command: 'stats', description: '系统统计' },
-            { command: 'detail', description: '任务详情' },
-            { command: 'logs', description: '查看日志' },
-            { command: 'subs', description: '订阅列表' },
-            { command: 'cancel', description: '取消当前操作' },
+            { command: 'help', description: '打开全功能按钮菜单' },
         ]);
 
         // 加载默认账号

--- a/src/services/telegramBot/handlers/basics.js
+++ b/src/services/telegramBot/handlers/basics.js
@@ -4,13 +4,13 @@
 const ConfigService = require('../../ConfigService');
 const { send, edit, deleteMsg } = require('../messaging');
 const { helpText, desensitizeUsername } = require('../templates');
-const { helpNavKeyboard, serializeCb } = require('../keyboards');
+const { mainMenuKeyboard, serializeCb } = require('../keyboards');
 const { escapeHtml } = require('../escape');
 const { CB } = require('../constants');
 
 async function handleHelp(svc, msg) {
     const text = helpText();
-    const keyboard = helpNavKeyboard();
+    const keyboard = mainMenuKeyboard();
     await send(svc.bot, msg.chat.id, text, { keyboard });
 }
 
@@ -25,18 +25,12 @@ async function handleStart(svc, msg) {
         '',
         currentAccount,
         '',
-        '推荐你按这个顺序开始：',
-        '1. /accounts 选择账号',
-        '2. /fl 查看常用目录',
-        '3. 直接发送 cloud.189.cn 分享链接创建任务',
-        '4. /search_cs 搜索 CloudSaver 资源',
-        '5. /hdhive 搜索影巢资源',
-        '6. /tasks 查看当前任务',
+        '点击下方按钮即可使用全部功能。',
+        '创建转存任务时，也可以直接发送 cloud.189.cn 分享链接。',
         '',
-        '常用快捷命令：',
-        '/help /tasks /hdhive /stats /logs /subs',
+        '需要输入关键词的功能会在点击后提示输入。',
     ].join('\n');
-    const keyboard = helpNavKeyboard();
+    const keyboard = mainMenuKeyboard();
     await send(svc.bot, chatId, text, { keyboard });
 }
 
@@ -95,6 +89,7 @@ async function handleSetAccount(svc, chatId, data, messageId) {
 async function handleCancel(svc, msg) {
     const chatId = msg.chat.id;
     const session = svc.sessionStore.get(chatId);
+    session.inputMode = null;
 
     // 清除搜索模式
     if (session.search.timeoutRef) {
@@ -130,6 +125,55 @@ async function handleCancel(svc, msg) {
     }
 
     await send(svc.bot, chatId, '已取消当前操作');
+}
+
+async function handleMainMenu(svc, chatId, action, messageId) {
+    const msg = { chat: { id: chatId } };
+    const session = svc.sessionStore.get(chatId);
+    // 切换菜单功能时，不能让上一个“等待输入”状态接管新消息。
+    session.inputMode = null;
+    const requireAccount = async (handler) => {
+        if (!svc.checkAccount(chatId)) {
+            await send(svc.bot, chatId, '请先点击“账号”按钮选择账号');
+            return;
+        }
+        await handler();
+    };
+
+    switch (action) {
+        case 'accounts': return showAccounts(svc, chatId);
+        case 'tasks': return requireAccount(() => require('./tasks').handleTaskPage(svc, chatId, 1));
+        case 'tasks_pending': return requireAccount(() => require('./tasks').handleTaskPage(svc, chatId, 1, null, 'pending'));
+        case 'tasks_processing': return requireAccount(() => require('./tasks').handleTaskPage(svc, chatId, 1, null, 'processing'));
+        case 'tasks_failed': return requireAccount(() => require('./tasks').handleTaskPage(svc, chatId, 1, null, 'failed'));
+        case 'search': return require('./search').handleSearchMode(svc, msg);
+        case 'hdhive': return require('./hdhive').handleHdhive(svc, msg);
+        case 'pt_search': return require('./ptSearch').handlePtSearch(svc, msg);
+        case 'folders': return requireAccount(() => require('./folders').handleCommonFolders(svc, msg));
+        case 'folder_add': return requireAccount(() => require('./folders').handleFolderTree(svc, msg));
+        case 'stats': return require('./stats').handleStats(svc, msg);
+        case 'logs': return require('./logs').handleLogs(svc, msg);
+        case 'subs': return require('./subs').handleSubs(svc, msg);
+        case 'pt_subs': return require('./ptSubs').handlePtSubs(svc, msg);
+        case 'hdhive_checkin': return require('./hdhive').handleCheckin(svc, msg);
+        case 'silent':
+            if (!svc.checkAdmin(chatId)) return send(svc.bot, chatId, '⚠️ 仅管理员可执行该操作');
+            return handleSilentMode(svc, msg);
+        case 'cancel': return handleCancel(svc, msg);
+        case 'help': return handleHelp(svc, msg);
+        case 'execute_all':
+            if (!svc.checkAdmin(chatId)) return send(svc.bot, chatId, '⚠️ 仅管理员可执行该操作');
+            return require('./tasks').handleExecuteAll(svc, msg);
+        case 'series':
+        case 'lazy_series':
+        case 'tmdb':
+            session.inputMode = action;
+            return send(svc.bot, chatId, action === 'tmdb'
+                ? '🎬 请输入 TMDB 搜索关键词，可在末尾附加年份'
+                : `📺 请输入剧名，可在末尾附加年份\n模式：${action === 'series' ? '普通追剧' : '懒转存 STRM'}\n\n点击“取消操作”可退出`);
+        default:
+            return handleStart(svc, msg);
+    }
 }
 
 async function handleHelpNav(svc, chatId, view, messageId) {
@@ -187,4 +231,5 @@ module.exports = {
     handleHelpNav,
     handleSilentMode,
     handleSilentModeCallback,
+    handleMainMenu,
 };

--- a/src/services/telegramBot/handlers/folders.js
+++ b/src/services/telegramBot/handlers/folders.js
@@ -3,7 +3,7 @@
  */
 const { send, edit, typing, deleteMsg } = require('../messaging');
 const { commonFolderList, desensitizeUsername } = require('../templates');
-const { folderKeyboard, serializeCb } = require('../keyboards');
+const { folderKeyboard, serializeCb, truncateBtn } = require('../keyboards');
 const { escapeHtml } = require('../escape');
 const { friendlyError } = require('../errors');
 const { CB } = require('../constants');
@@ -18,10 +18,14 @@ async function handleCommonFolders(svc, msg) {
         order: { path: 'ASC' },
     });
 
-    const keyboard = [[{
+    const keyboard = folders.map(folder => [{
+        text: truncateBtn(`🗑 ${folder.path}`, 36),
+        callback_data: serializeCb({ t: CB.FOLDER_DELETE, f: folder.id }),
+    }]);
+    keyboard.push([{
         text: '📁 添加常用目录',
         callback_data: serializeCb({ t: CB.FOLDER_DRILL, f: '-11' }),
-    }]];
+    }]);
 
     const username = session.account.entity?.username;
     const message = commonFolderList(folders, username);
@@ -191,10 +195,15 @@ async function handleDeleteFolder(svc, msg, folderId) {
     }
 }
 
+async function handleDeleteFolderCb(svc, chatId, folderId) {
+    await handleDeleteFolder(svc, { chat: { id: chatId } }, folderId);
+}
+
 module.exports = {
     handleCommonFolders,
     handleFolderTree,
     handleFolderDrill,
     handleFolderSave,
     handleDeleteFolder,
+    handleDeleteFolderCb,
 };

--- a/src/services/telegramBot/handlers/ptSearch.js
+++ b/src/services/telegramBot/handlers/ptSearch.js
@@ -107,7 +107,7 @@ async function handlePtSearchMessage(svc, msg) {
 
             if (r.groups?.length) {
                 session.ptSearch.groups = r.groups;
-                text += '可用字幕组（输入编号选择）：\n';
+                text += '可用字幕组（点击按钮选择）：\n';
                 r.groups.forEach((g, i) => {
                     text += `${i + 1}. ${escapeHtml(g.name)} (${g.itemCount} 个资源)\n`;
                 });
@@ -116,7 +116,11 @@ async function handlePtSearchMessage(svc, msg) {
                 session.ptSearch.active = false;
             }
 
-            await edit(svc.bot, chatId, statusMsg?.message_id, text);
+            const keyboard = r.groups?.map((g, i) => [{
+                text: `${i + 1}. ${g.name}`,
+                callback_data: serializeCb({ t: CB.PT_SEARCH_GROUP, i: i + 1 }),
+            }]) || [];
+            await edit(svc.bot, chatId, statusMsg?.message_id, text, { keyboard });
             return;
         }
 
@@ -125,9 +129,13 @@ async function handlePtSearchMessage(svc, msg) {
         results.forEach((r, i) => {
             text += `${i + 1}. ${escapeHtml(r.title)}\n`;
         });
-        text += '\n输入编号选择番剧';
+        text += '\n点击按钮选择番剧';
 
-        await edit(svc.bot, chatId, statusMsg?.message_id, text);
+        const keyboard = results.map((r, i) => [{
+            text: `${i + 1}. ${r.title}`.substring(0, 40),
+            callback_data: serializeCb({ t: CB.PT_SEARCH_RESULT, i: i + 1 }),
+        }]);
+        await edit(svc.bot, chatId, statusMsg?.message_id, text, { keyboard });
     } catch (error) {
         await edit(svc.bot, chatId, statusMsg?.message_id, friendlyError(error));
     }
@@ -157,16 +165,32 @@ async function handleResultSelect(svc, chatId, result) {
             return;
         }
 
-        let text = `${bold(escapeHtml(result.title))}\n\n选择字幕组（输入编号）：\n\n`;
+        let text = `${bold(escapeHtml(result.title))}\n\n选择字幕组：\n\n`;
         groups.forEach((g, i) => {
             const extra = g.itemCount ? ` (${g.itemCount} 个资源)` : '';
             text += `${i + 1}. ${escapeHtml(g.name)}${extra}\n`;
         });
 
-        await edit(svc.bot, chatId, statusMsg?.message_id, text);
+        const keyboard = groups.map((g, i) => [{
+            text: `${i + 1}. ${g.name}`.substring(0, 40),
+            callback_data: serializeCb({ t: CB.PT_SEARCH_GROUP, i: i + 1 }),
+        }]);
+        await edit(svc.bot, chatId, statusMsg?.message_id, text, { keyboard });
     } catch (error) {
         await edit(svc.bot, chatId, statusMsg?.message_id, friendlyError(error));
     }
+}
+
+async function handleResultCallback(svc, chatId, index) {
+    const result = svc.sessionStore.get(chatId).ptSearch.results[Number(index) - 1];
+    if (!result) return send(svc.bot, chatId, '⚠️ 搜索结果已失效，请重新搜索');
+    await handleResultSelect(svc, chatId, result);
+}
+
+async function handleGroupCallback(svc, chatId, index, messageId) {
+    const group = svc.sessionStore.get(chatId).ptSearch.groups[Number(index) - 1];
+    if (!group) return send(svc.bot, chatId, '⚠️ 字幕组结果已失效，请重新搜索');
+    await showRssResult(svc, chatId, group, messageId);
 }
 
 // ─── 显示最终 RSS 结果 ───
@@ -213,4 +237,6 @@ module.exports = {
     handlePtSearch,
     handleSiteSelect,
     handlePtSearchMessage,
+    handleResultCallback,
+    handleGroupCallback,
 };

--- a/src/services/telegramBot/handlers/ptSubs.js
+++ b/src/services/telegramBot/handlers/ptSubs.js
@@ -51,6 +51,13 @@ async function handlePtSubsPage(svc, chatId, page = 1, messageId = null) {
         });
 
         const keyboard = [];
+        subs.forEach(sub => {
+            keyboard.push([
+                { text: `📝 ${String(sub.name).substring(0, 18)}`, callback_data: serializeCb({ t: CB.PT_SUB_DETAIL, i: sub.id }) },
+                { text: '🔄 刷新', callback_data: serializeCb({ t: CB.PT_SUB_REFRESH, i: sub.id }) },
+                { text: '📋 Releases', callback_data: serializeCb({ t: CB.PT_RELEASE_PAGE, i: sub.id, p: 1 }) },
+            ]);
+        });
         const pageRow = paginationRow(CB.PT_SUB_PAGE, page, totalPages);
         if (pageRow.length > 0) keyboard.push(pageRow);
 
@@ -154,6 +161,10 @@ async function handlePtDetail(svc, msg, subId) {
     }
 }
 
+async function handlePtDetailCb(svc, chatId, subId) {
+    await handlePtDetail(svc, { chat: { id: chatId } }, subId);
+}
+
 // ─── /pt_refresh_<ID> ───
 async function handlePtRefresh(svc, msg, subId) {
     const chatId = msg.chat.id;
@@ -239,16 +250,15 @@ async function handlePtReleasesPage(svc, chatId, subId, page = 1, messageId = nu
         const totalPages = Math.ceil(total / pageSize);
 
         let text = `📋 ${bold(escapeHtml(sub.name))} Releases (第${page}页，共${total}个)\n\n`;
+        const keyboard = [];
         releases.forEach((rel, i) => {
             text += ptReleaseCard(rel, skip + i + 1) + '\n';
-            // 操作按钮用命令链接
             if (rel.status === 'failed' || rel.status === 'upload_failed') {
-                text += `   🔁 重试：/pt_retry_${rel.id}  🗑 删除：/pt_del_${rel.id}\n`;
+                keyboard.push(ptReleaseActionRow(rel.id));
             }
             text += '\n';
         });
 
-        const keyboard = [];
         const pageRow = paginationRow(CB.PT_RELEASE_PAGE, page, totalPages);
         if (pageRow.length > 0) keyboard.push(pageRow);
 
@@ -295,6 +305,7 @@ module.exports = {
     handlePtSubs,
     handlePtSubsPage,
     handlePtDetail,
+    handlePtDetailCb,
     handlePtRefresh,
     handlePtToggle,
     handlePtRefreshCb,

--- a/src/services/telegramBot/handlers/search.js
+++ b/src/services/telegramBot/handlers/search.js
@@ -6,6 +6,7 @@ const { searchResults } = require('../templates');
 const { escapeHtml, bold, link } = require('../escape');
 const { friendlyError } = require('../errors');
 const { SEARCH_TIMEOUT_MS } = require('../constants');
+const { cloudSearchKeyboard } = require('../keyboards');
 
 // ─── /search_cs ───
 async function handleSearchMode(svc, msg) {
@@ -86,9 +87,26 @@ async function handleSearchMessage(svc, msg) {
         });
 
         const text = searchResults(result);
-        await edit(svc.bot, chatId, statusMsg?.message_id, `搜索结果：\n\n${text}`);
+        await edit(svc.bot, chatId, statusMsg?.message_id, `搜索结果：\n\n${text}`, {
+            keyboard: cloudSearchKeyboard(result),
+        });
     } catch (error) {
         await edit(svc.bot, chatId, statusMsg?.message_id, friendlyError(error));
+    }
+}
+
+async function handleSearchResultCallback(svc, chatId, index) {
+    const session = svc.sessionStore.get(chatId);
+    const cacheShareLink = session.search.resultMap.get(Number(index));
+    if (!cacheShareLink) {
+        await send(svc.bot, chatId, '⚠️ 搜索结果已失效，请重新搜索');
+        return;
+    }
+    try {
+        const { url: shareLink, accessCode } = svc.cloud189Utils.parseCloudShare(cacheShareLink);
+        await require('./share').processShareLink(svc, chatId, shareLink, accessCode);
+    } catch (error) {
+        await send(svc.bot, chatId, friendlyError(error));
     }
 }
 
@@ -176,4 +194,5 @@ module.exports = {
     handleSearchMode,
     handleSearchMessage,
     handleTmdb,
+    handleSearchResultCallback,
 };

--- a/src/services/telegramBot/handlers/stats.js
+++ b/src/services/telegramBot/handlers/stats.js
@@ -3,6 +3,8 @@
  */
 const { send, typing } = require('../messaging');
 const { statsCard } = require('../templates');
+const { serializeCb } = require('../keyboards');
+const { CB } = require('../constants');
 const { friendlyError } = require('../errors');
 
 async function handleStats(svc, msg) {
@@ -39,7 +41,15 @@ async function handleStats(svc, msg) {
         });
 
         const text = statsCard(statusCounts, recentCount, failedTasks);
-        await send(svc.bot, chatId, text);
+        const keyboard = failedTasks.map(task => [{
+            text: `🔁 重试 ${String(task.resourceName || `任务 #${task.id}`).substring(0, 24)}`,
+            callback_data: serializeCb({ t: CB.TASK_RETRY, i: task.id }),
+        }]);
+        keyboard.push([{
+            text: '🔄 刷新统计',
+            callback_data: serializeCb({ t: CB.STATS_REFRESH }),
+        }]);
+        await send(svc.bot, chatId, text, { keyboard });
     } catch (error) {
         await send(svc.bot, chatId, friendlyError(error));
     }

--- a/src/services/telegramBot/handlers/tasks.js
+++ b/src/services/telegramBot/handlers/tasks.js
@@ -3,7 +3,7 @@
  */
 const { send, edit, typing, deleteMsg } = require('../messaging');
 const { taskCard, taskDetailCard, formatStatus } = require('../templates');
-const { paginationRow, serializeCb, taskActionRow } = require('../keyboards');
+const { paginationRow, serializeCb, taskActionRow, taskListKeyboard } = require('../keyboards');
 const { friendlyError } = require('../errors');
 const { CB, TASK_STATUS } = require('../constants');
 
@@ -43,14 +43,13 @@ async function handleTaskPage(svc, chatId, page = 1, messageId = null, status = 
 
     const totalPages = Math.max(1, Math.ceil(total / pageSize));
     const taskList = tasks.map(t => taskCard(t)).join('\n\n');
-    const keyboard = [];
     const title = getTaskListTitle(status);
 
     const pageRow = paginationRow(CB.TASK_PAGE, page, totalPages);
-    if (pageRow.length > 0) keyboard.push(pageRow);
+    const keyboard = taskListKeyboard(tasks, pageRow);
 
     const emptyTips = status
-        ? `📭 暂无${title}，可使用 /tasks 查看全部任务`
+        ? `📭 暂无${title}，可从主菜单点击“全部任务”查看`
         : '📭 暂无任务，可先发送 cloud.189.cn 分享链接创建任务';
     const message = tasks.length > 0
         ? `📋 ${title} (第${page}页，共${total}个)：\n\n${taskList}`
@@ -246,6 +245,14 @@ async function handleExecuteCb(svc, chatId, taskId, messageId) {
     await handleExecute(svc, { chat: { id: chatId } }, taskId);
 }
 
+async function handleStrmCb(svc, chatId, taskId) {
+    await handleStrm(svc, { chat: { id: chatId } }, taskId);
+}
+
+async function handleEmbyCb(svc, chatId, taskId) {
+    await handleEmby(svc, { chat: { id: chatId } }, taskId);
+}
+
 // ─── 创建任务（选择目录后的回调） ───
 async function handleCreateTask(svc, chatId, data, messageId) {
     const session = svc.sessionStore.get(chatId);
@@ -320,5 +327,7 @@ module.exports = {
     handleRetry,
     handleRetryCb,
     handleExecuteCb,
+    handleStrmCb,
+    handleEmbyCb,
     handleCreateTask,
 };

--- a/src/services/telegramBot/keyboards.js
+++ b/src/services/telegramBot/keyboards.js
@@ -120,8 +120,30 @@ function taskActionRow(taskId) {
     return [
         { text: '🔄 执行', callback_data: serializeCb({ t: CB.TASK_EXECUTE, i: taskId }) },
         { text: '🔁 重试', callback_data: serializeCb({ t: CB.TASK_RETRY, i: taskId }) },
+        { text: '📁 STRM', callback_data: serializeCb({ t: CB.TASK_STRM, i: taskId }) },
+        { text: '🎬 Emby', callback_data: serializeCb({ t: CB.TASK_EMBY, i: taskId }) },
+        { text: '📜 日志', callback_data: serializeCb({ t: CB.TASK_LOGS, i: taskId }) },
         { text: '🗑 删除', callback_data: serializeCb({ t: CB.DELETE_TASK, i: taskId, p: true }) },
     ];
+}
+
+function taskListKeyboard(tasks, pageRow = []) {
+    const rows = [];
+    for (const task of tasks) {
+        const name = truncateBtn(task.resourceName || `任务 #${task.id}`, 18);
+        rows.push([
+            { text: `📝 ${name}`, callback_data: serializeCb({ t: CB.TASK_DETAIL, i: task.id }) },
+            { text: '▶️ 执行', callback_data: serializeCb({ t: CB.TASK_EXECUTE, i: task.id }) },
+        ]);
+        rows.push([
+            { text: '📁 STRM', callback_data: serializeCb({ t: CB.TASK_STRM, i: task.id }) },
+            { text: '🎬 Emby', callback_data: serializeCb({ t: CB.TASK_EMBY, i: task.id }) },
+            { text: '📜 日志', callback_data: serializeCb({ t: CB.TASK_LOGS, i: task.id }) },
+            { text: '🗑 删除', callback_data: serializeCb({ t: CB.DELETE_TASK, i: task.id, p: true }) },
+        ]);
+    }
+    if (pageRow.length > 0) rows.push(pageRow);
+    return rows;
 }
 
 /**
@@ -161,6 +183,31 @@ function helpNavKeyboard() {
     ];
 }
 
+function mainMenuKeyboard() {
+    const button = (text, action) => ({
+        text,
+        callback_data: serializeCb({ t: CB.MAIN_MENU, a: action }),
+    });
+    return [
+        [button('👤 账号', 'accounts'), button('📋 全部任务', 'tasks')],
+        [button('⏳ 待执行', 'tasks_pending'), button('🔄 执行中', 'tasks_processing'), button('❌ 失败', 'tasks_failed')],
+        [button('🔍 CloudSaver', 'search'), button('🎞 影巢', 'hdhive'), button('📡 PT 搜索', 'pt_search')],
+        [button('📺 自动追剧', 'series'), button('⚡ 懒转存追剧', 'lazy_series'), button('🎬 TMDB', 'tmdb')],
+        [button('📁 常用目录', 'folders'), button('➕ 添加目录', 'folder_add')],
+        [button('📊 统计', 'stats'), button('📜 日志', 'logs'), button('🔔 分享订阅', 'subs')],
+        [button('📡 PT 订阅', 'pt_subs'), button('✅ 影巢签到', 'hdhive_checkin')],
+        [button('🔇 静默模式', 'silent'), button('▶️ 执行全部', 'execute_all')],
+        [button('✖️ 取消操作', 'cancel'), button('❓ 帮助', 'help')],
+    ];
+}
+
+function cloudSearchKeyboard(results = []) {
+    return results.slice(0, 20).map((item, index) => [{
+        text: truncateBtn(`${index + 1}. 📥 ${item?.title || '未命名资源'}`, 36),
+        callback_data: serializeCb({ t: CB.SEARCH_RESULT, i: index + 1 }),
+    }]);
+}
+
 /**
  * 构建影巢搜索结果键盘
  */
@@ -197,9 +244,12 @@ module.exports = {
     multiColumn,
     folderKeyboard,
     taskActionRow,
+    taskListKeyboard,
     ptSubActionRow,
     ptReleaseActionRow,
     helpNavKeyboard,
+    mainMenuKeyboard,
+    cloudSearchKeyboard,
     hdhiveSearchKeyboard,
     hdhiveResourceKeyboard,
 };

--- a/src/services/telegramBot/router.js
+++ b/src/services/telegramBot/router.js
@@ -308,6 +308,16 @@ function registerCommands(svc) {
         if (msg.text?.startsWith('/')) return;
         // PT 搜索模式优先
         const session = svc.sessionStore.get(msg.chat.id);
+        if (session.inputMode) {
+            const mode = session.inputMode;
+            session.inputMode = null;
+            if (mode === 'tmdb') {
+                await getHandlers().search.handleTmdb(svc, msg, msg.text?.trim() || '');
+            } else {
+                await getHandlers().series.handleSeries(svc, msg, msg.text?.trim() || '', mode === 'series' ? 'normal' : 'lazy');
+            }
+            return;
+        }
         if (session.ptSearch.active) {
             await getHandlers().ptSearch.handlePtSearchMessage(svc, msg);
             return;
@@ -330,6 +340,10 @@ function registerCommands(svc) {
 
         const chatId = callbackQuery.message.chat.id;
         const messageId = callbackQuery.message.message_id;
+        if (!svc.checkChatId(chatId)) {
+            await bot.answerCallbackQuery(callbackQuery.id, { text: '无权操作' }).catch(() => {});
+            return;
+        }
 
         try {
             const handled = await withCallbackLock(callbackQuery, data, async () => {
@@ -387,6 +401,18 @@ function registerCommands(svc) {
                     case CB.TASK_EXECUTE:
                         await getHandlers().tasks.handleExecuteCb(svc, chatId, data.i, messageId);
                         break;
+                    case CB.TASK_STRM:
+                        await getHandlers().tasks.handleStrmCb(svc, chatId, data.i);
+                        break;
+                    case CB.TASK_EMBY:
+                        await getHandlers().tasks.handleEmbyCb(svc, chatId, data.i);
+                        break;
+                    case CB.TASK_LOGS:
+                        await getHandlers().logs.handleLogs(svc, { chat: { id: chatId } }, data.i);
+                        break;
+                    case CB.STATS_REFRESH:
+                        await getHandlers().stats.handleStats(svc, { chat: { id: chatId } });
+                        break;
                     case CB.TASK_RETRY:
                         if (!svc.checkAdmin(chatId)) {
                             await send(bot, chatId, '⚠️ 仅管理员可执行该操作');
@@ -400,17 +426,43 @@ function registerCommands(svc) {
                     case CB.HELP_NAV:
                         await getHandlers().basics.handleHelpNav(svc, chatId, data.v, messageId);
                         break;
+                    case CB.MAIN_MENU:
+                        await getHandlers().basics.handleMainMenu(svc, chatId, data.a, messageId);
+                        break;
+                    case CB.SEARCH_RESULT:
+                        await getHandlers().search.handleSearchResultCallback(svc, chatId, data.i);
+                        break;
+                    case CB.FOLDER_DELETE:
+                        if (!svc.checkAdmin(chatId)) {
+                            await send(bot, chatId, '⚠️ 仅管理员可执行该操作');
+                            return;
+                        }
+                        await getHandlers().folders.handleDeleteFolderCb(svc, chatId, data.f);
+                        break;
                     case CB.SUBS_PAGE:
                         await getHandlers().subs.handleSubsPage(svc, chatId, data.p, messageId);
                         break;
                     case CB.SILENT_MODE:
+                        if (!svc.checkAdmin(chatId)) {
+                            await send(bot, chatId, '⚠️ 仅管理员可执行该操作');
+                            return;
+                        }
                         await getHandlers().basics.handleSilentModeCallback(svc, chatId, data, messageId);
                         break;
                     case CB.PT_SEARCH_SITE:
                         await getHandlers().ptSearch.handleSiteSelect(svc, chatId, messageId, data.s);
                         break;
+                    case CB.PT_SEARCH_RESULT:
+                        await getHandlers().ptSearch.handleResultCallback(svc, chatId, data.i);
+                        break;
+                    case CB.PT_SEARCH_GROUP:
+                        await getHandlers().ptSearch.handleGroupCallback(svc, chatId, data.i, messageId);
+                        break;
                     case CB.PT_SUB_PAGE:
                         await getHandlers().ptSubs.handlePtSubsPage(svc, chatId, data.p, messageId);
+                        break;
+                    case CB.PT_SUB_DETAIL:
+                        await getHandlers().ptSubs.handlePtDetailCb(svc, chatId, data.i);
                         break;
                     case CB.PT_RELEASE_PAGE:
                         await getHandlers().ptSubs.handlePtReleasesPage(svc, chatId, data.i, data.p, messageId);

--- a/src/services/telegramBot/session.js
+++ b/src/services/telegramBot/session.js
@@ -96,6 +96,7 @@ class SessionStore {
                 taskListFilter: null,
                 commonFolderListMsgId: null,
             },
+            inputMode: null,
             search: {
                 active: false,
                 timeoutRef: null,

--- a/src/services/telegramBot/templates.js
+++ b/src/services/telegramBot/templates.js
@@ -42,12 +42,7 @@ function taskCard(task) {
         `⏱ 进度：${escapeHtml(episodes)}\n` +
         `🔄 状态：${status}\n` +
         `⌚️ 更新：${escapeHtml(updated)}\n` +
-        `▶️ 执行：/execute_${task.id}\n` +
-        `📁 STRM：/strm_${task.id}\n` +
-        `🎬 Emby：/emby_${task.id}\n` +
-        `📝 详情：/detail_${task.id}\n` +
-        `📜 日志：/logs_${task.id}\n` +
-        `❌ 删除：/dt_${task.id}`
+        `🆔 ID：${task.id}`
     );
 }
 
@@ -102,7 +97,7 @@ function statsCard(statusCounts, recentCount, failedTasks) {
             const err = task.lastError
                 ? escapeHtml(task.lastError.substring(0, 60))
                 : '未知错误';
-            text += `  ${i + 1}. ${name}\n     ${err}\n     /retry_${task.id}\n`;
+            text += `  ${i + 1}. ${name}\n     ${err}\n`;
         });
     }
 
@@ -115,50 +110,13 @@ function statsCard(statusCounts, recentCount, failedTasks) {
 function helpText() {
     return (
         `🤖 ${bold('天翼云盘机器人使用指南')}\n\n` +
-        `📋 ${bold('基础命令')}\n` +
-        `/start - 首次使用引导\n` +
-        `/help - 显示帮助信息\n` +
-        `/accounts - 账号列表与切换\n` +
-        `/tasks - 显示下载任务列表\n` +
-        `/tasks_failed - 查看失败任务\n` +
-        `/tasks_pending - 查看待执行任务\n` +
-        `/tasks_processing - 查看执行中任务\n` +
-        `/fl - 显示常用目录列表\n` +
-        `/fs - 添加常用目录\n` +
-        `/stats - 系统统计信息\n` +
-        `/silent - 静默模式设置\n` +
-        `/cancel - 取消当前操作\n\n` +
-        `🔍 ${bold('搜索与追剧')}\n` +
-        `/search_cs - 搜索CloudSaver资源\n` +
-        `/hdhive [关键字] - 搜索影巢资源\n` +
-        `/hdhive_checkin - 影巢签到\n` +
-        `/series 剧名 [年份] - 自动追剧(正常任务)\n` +
-        `/lazy_series 剧名 [年份] - 自动追剧(懒转存STRM)\n\n` +
-        `📝 ${bold('任务操作')}\n` +
-        `/execute_[ID] - 执行指定任务\n` +
-        `/execute_all - 执行所有任务\n` +
-        `/detail_[ID] - 查看任务详情\n` +
-        `/retry_[ID] - 重试失败任务\n` +
-        `/strm_[ID] - 生成STRM文件\n` +
-        `/emby_[ID] - 通知Emby刷新\n` +
-        `/dt_[ID] - 删除指定任务\n` +
-        `/df_[ID] - 删除指定常用目录\n\n` +
-        `📋 ${bold('日志与订阅')}\n` +
-        `/logs - 查看最近日志\n` +
-        `/subs - 查看订阅列表\n\n` +
-        `📡 ${bold('PT 管理')}\n` +
-        `/pt_subs - PT 订阅列表\n` +
-        `/pt_detail_[ID] - PT 订阅详情\n` +
-        `/pt_refresh_[ID] - 刷新 PT 订阅\n` +
-        `/pt_releases_[ID] - 查看 Releases\n` +
-        `/pt_search - PT 站点搜索\n\n` +
-        `📥 ${bold('创建任务')}\n` +
-        `直接发送天翼云盘分享链接即可创建任务\n` +
-        `格式：链接（支持访问码的链接）\n\n` +
-        `🎬 ${bold('自动追剧')}\n` +
-        `1. /series 北上 2025\n` +
-        `2. /lazy_series 北上 2025\n` +
-        `3. 使用系统页里配置的默认账号与默认目录`
+        `全部功能已放在下方按钮菜单中，无需记忆命令。\n\n` +
+        `📋 ${bold('任务')}：查看各状态任务，并通过按钮执行、重试、生成 STRM、刷新 Emby、看日志或删除。\n` +
+        `🔍 ${bold('搜索')}：支持 CloudSaver、影巢、PT 与 TMDB。\n` +
+        `📺 ${bold('追剧')}：点击普通追剧或懒转存追剧后输入剧名和年份。\n` +
+        `📁 ${bold('目录')}：查看、添加和删除常用目录。\n` +
+        `📡 ${bold('订阅')}：查看分享订阅和 PT 订阅。\n\n` +
+        `创建转存任务仍可直接发送天翼云盘分享链接（支持访问码）。`
     );
 }
 
@@ -170,9 +128,7 @@ function commonFolderList(folders, username) {
     if (!folders || folders.length === 0) {
         return `当前账号: ${escapeHtml(user)}\n未找到常用目录，请先添加常用目录`;
     }
-    const list = folders.map(f =>
-        `📁 ${escapeHtml(f.path)}\n❌ 删除: /df_${f.id}`
-    ).join('\n\n');
+    const list = folders.map(f => `📁 ${escapeHtml(f.path)}`).join('\n\n');
     return `当前账号: ${escapeHtml(user)}\n常用目录列表：\n\n${list}`;
 }
 
@@ -239,10 +195,7 @@ function ptSubCard(sub, index) {
         missingLine +
         `   最后检查：${escapeHtml(lastCheck)}\n` +
         `   检查结果：${lastStatus}\n` +
-        `   Release 数：${sub.releaseCount || 0}\n` +
-        `   📝 详情：/pt_detail_${sub.id}\n` +
-        `   🔄 刷新：/pt_refresh_${sub.id}\n` +
-        `   📋 Releases：/pt_releases_${sub.id}`
+        `   Release 数：${sub.releaseCount || 0}`
     );
 }
 


### PR DESCRIPTION
## 变更内容

- 将 Telegram Bot 的 `/start`、`/help` 改为全功能按钮菜单，并保留旧命令兼容
- 为任务操作、CloudSaver/影巢/PT 搜索结果、常用目录、统计、PT 订阅等流程补充按钮交互
- 追剧、懒转存追剧和 TMDB 搜索改为点击按钮后等待文本输入
- 切换主菜单功能时清理输入状态，修复影巢搜索被残留 TMDB 状态接管的问题
- 增加 callback 的 Chat ID 与管理员权限校验

## 验证

- `npm run build`
- `node --test test/*.test.js`（18/18 通过）
- Telegram Bot JavaScript 文件通过 `node --check`
- `git diff --check`
