### PR TITLE
feat(media): 动漫专用解析、电影合集、特别篇季与媒体来源修复

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmmirror.com/

--- a/frontend/src/components/tabs/AutoSeriesTab.tsx
+++ b/frontend/src/components/tabs/AutoSeriesTab.tsx
@@ -468,8 +468,8 @@ const AutoSeriesTab: React.FC = () => {
                   onChange={e => setForm({ ...form, mode: e.target.value as AutoSeriesMode })}
                   className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
                 >
-                  <option value="lazy">懒转存 (生成STRM)</option>
-                  <option value="normal">自动转存 (下载文件)</option>
+                  <option value="lazy">懒转存 (生成STRM，播放时转存)</option>
+                  <option value="normal">自动转存 (保存到网盘)</option>
                 </select>
               </div>
             </div>

--- a/frontend/src/components/tabs/MediaTab.tsx
+++ b/frontend/src/components/tabs/MediaTab.tsx
@@ -131,7 +131,10 @@ const initialSettings: MediaSettings = {
     hasApiKey: false,
     model: '',
     flowControlEnabled: false,
-    rename: { template: '{name} - {se}{ext}', movieTemplate: '{name} ({year}){ext}' }
+    rename: {
+      template: '{{name}} - {{se}}{{ext}}',
+      movieTemplate: '{{name}}{% if year %} ({{year}}){% endif %}{{ext}}'
+    }
   },
   alist: { enable: false, baseUrl: '', apiKey: '', hasApiKey: false },
   organizer: {
@@ -490,7 +493,7 @@ const MediaTab: React.FC = () => {
           <div className="bg-blue-50 p-4 rounded-2xl border border-blue-100 flex gap-3">
             <AlertCircle size={20} className="text-blue-600 shrink-0 mt-0.5" />
             <p className="text-xs text-blue-800 leading-relaxed">
-              启用后AI重命名将优先执行。剧集模板示例：<code className="bg-blue-100 px-1.5 py-0.5 rounded text-blue-900">{'{name} - S{s}E{e}{ext}'}</code> → 北上 - S01E01.mkv
+              支持 Nunjucks 条件语法并兼容旧占位符。剧集示例：<code className="bg-blue-100 px-1.5 py-0.5 rounded text-blue-900">{'{{name}} - {{se}}{{ext}}'}</code>；电影可用 <code className="bg-blue-100 px-1.5 py-0.5 rounded text-blue-900">{'{% if year %}'}</code> 在年份为空时省略括号。
             </p>
           </div>
         </div>

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -14,6 +14,23 @@ const parseIntOr = (raw: string, fallback: number) => {
   return Number.isFinite(n) ? n : fallback;
 };
 
+const getDailyTimeFromCron = (cronExpression: string) => {
+  const match = cronExpression.trim().match(/^(\d{1,2})\s+(\d{1,2})\s+\*\s+\*\s+\*$/);
+  if (!match) return '';
+
+  const minute = Number(match[1]);
+  const hour = Number(match[2]);
+  if (minute > 59 || hour > 23) return '';
+
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+};
+
+const getDailyCronFromTime = (time: string) => {
+  const match = time.match(/^([01]\d|2[0-3]):([0-5]\d)$/);
+  if (!match) return '';
+  return `${Number(match[2])} ${Number(match[1])} * * *`;
+};
+
 interface CustomPushConfig {
   name: string;
   description: string;
@@ -281,6 +298,7 @@ const SettingsTab: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [keepAliveRunning, setKeepAliveRunning] = useState(false);
+  const lazyFileDailyCleanupTime = getDailyTimeFromCron(settings.task.lazyFileCleanupCron);
 
   // Folder Selector State
   const [isFolderSelectorOpen, setIsFolderSelectorOpen] = useState(false);
@@ -444,6 +462,16 @@ const SettingsTab: React.FC = () => {
   };
 
   const handleSave = async () => {
+    if (!Number.isFinite(settings.task.lazyFileRetentionHours) || settings.task.lazyFileRetentionHours < 1) {
+      toast.error('懒转存文件保留时长不能小于 1 小时');
+      return;
+    }
+
+    if (!settings.task.lazyFileCleanupCron.trim()) {
+      toast.error('懒转存清理 Cron 不能为空');
+      return;
+    }
+
     setSaving(true);
     try {
       const { regexPresets, ...mainSettings } = settings;
@@ -728,13 +756,32 @@ const SettingsTab: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium ui-title">懒转存清理定时 (Cron)</label>
-              <input 
-                type="text" 
-                value={settings.task.lazyFileCleanupCron}
-                onChange={(e) => updateSettings('task.lazyFileCleanupCron', e.target.value)}
+              <label className="text-sm font-medium ui-title">每天清理时间（快捷设置）</label>
+              <input
+                type="time"
+                value={lazyFileDailyCleanupTime}
+                onChange={(e) => {
+                  const cronExpression = getDailyCronFromTime(e.target.value);
+                  if (cronExpression) updateSettings('task.lazyFileCleanupCron', cronExpression);
+                }}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
+              <p className="text-xs text-slate-400">
+                {lazyFileDailyCleanupTime
+                  ? `当前每天 ${lazyFileDailyCleanupTime} 执行，选择新时间会同步更新 Cron。`
+                  : '当前使用自定义 Cron；选择时间后会改为每天执行一次。'}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium ui-title">懒转存清理定时（Cron，高级）</label>
+              <input
+                type="text"
+                value={settings.task.lazyFileCleanupCron}
+                onChange={(e) => updateSettings('task.lazyFileCleanupCron', e.target.value)}
+                placeholder="例如：0 3 * * *"
+                className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
+              />
+              <p className="text-xs text-slate-400">可直接填写复杂 Cron；例如每 6 小时执行一次：0 */6 * * *</p>
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium ui-title">Session 保活定时 (Cron)</label>
@@ -747,12 +794,15 @@ const SettingsTab: React.FC = () => {
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium ui-title">懒转存保留时间 (小时)</label>
-              <input 
-                type="number" 
+              <input
+                type="number"
+                min={1}
+                step={1}
                 value={settings.task.lazyFileRetentionHours}
                 onChange={(e) => updateSettings('task.lazyFileRetentionHours', parseIntOr(e.target.value, 24))}
                 className="w-full px-5 py-3 bg-slate-50 border border-slate-300 rounded-2xl text-sm outline-none focus:ring-2 focus:ring-[#0b57d0]/20"
               />
+              <p className="text-xs text-slate-400">云盘文件超过该时长后，会在下一次清理任务运行时删除。</p>
             </div>
             <div className="space-y-2 md:col-span-2">
               <label className="text-sm font-medium ui-title">媒体文件后缀</label>
@@ -804,6 +854,7 @@ const SettingsTab: React.FC = () => {
               </div>
               <div>
                 <span className="text-sm font-medium ui-title">自动清理懒转存文件</span>
+                <p className="text-[10px] text-slate-400">仅清理云盘缓存文件，不删除本地 STRM</p>
               </div>
             </label>
             <label className="flex items-center gap-3 cursor-pointer group p-4 rounded-2xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">

--- a/frontend/src/components/tabs/TaskTab.tsx
+++ b/frontend/src/components/tabs/TaskTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Plus, ChevronRight, Filter, Search, RefreshCw, Files, PlayCircle, MoreVertical, CheckCircle2, AlertCircle, Clock, Trash2, ClipboardList, Edit3 } from 'lucide-react';
+import { Plus, ChevronRight, Filter, Search, RefreshCw, Files, PlayCircle, MoreVertical, CheckCircle2, AlertCircle, Clock, Trash2, ClipboardList, Edit3, Film } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useToast } from '../ui/Toast';
 import { useDialog } from '../ui/Dialog';
@@ -44,10 +44,20 @@ interface Task {
   enableOrganizer: boolean;
   keepCasAfterRestore?: boolean;
   enableCron: boolean;
+  isCollection?: boolean;
 }
 
 interface TaskTabProps {
   onCreateTask: (initialData?: any) => void;
+}
+
+interface CollectionFile {
+  name: string;
+  title: string;
+  year: string | number;
+  tmdbId: string;
+  posterPath: string;
+  matched: boolean;
 }
 
 type TaskStatus = Task['status'];
@@ -103,6 +113,7 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
   const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   const [filterGroups, setFilterGroups] = useState<string[]>([]);
+  const [collectionModal, setCollectionModal] = useState<{ title: string; loading: boolean; files: CollectionFile[] } | null>(null);
 
   const fetchTasks = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -435,6 +446,24 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
       }
     } catch (error) {
       toast.error('TMDB 绑定失败');
+    }
+  };
+
+  const handleViewCollection = async (task: Task) => {
+    const title = task.tmdbTitle || task.resourceName || '合集详情';
+    setCollectionModal({ title, loading: true, files: [] });
+    try {
+      const response = await fetch(`/api/tasks/${task.id}/collection-files`);
+      const data = await response.json();
+      if (data.success && data.data?.isCollection) {
+        setCollectionModal({ title, loading: false, files: data.data.files || [] });
+      } else {
+        toast.error(data.error || '该任务不是电影合集');
+        setCollectionModal(null);
+      }
+    } catch (error) {
+      toast.error('获取合集详情失败');
+      setCollectionModal(null);
     }
   };
 
@@ -987,6 +1016,17 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
                           >
                             <RefreshCw size={14} /> 清理缓存
                           </button>
+                          {task.isCollection && (
+                            <button
+                              onClick={() => {
+                                setOpenTaskMenuId(null);
+                                handleViewCollection(task);
+                              }}
+                              className="w-full text-left px-3 py-1.5 hover:bg-slate-50 text-sm text-slate-700 transition-colors flex items-center gap-2"
+                            >
+                              <Film size={14} /> 查看合集详情
+                            </button>
+                          )}
                           <button
                             onClick={() => {
                               setOpenTaskMenuId(null);
@@ -1050,6 +1090,74 @@ const TaskTab: React.FC<TaskTabProps> = ({ onCreateTask }) => {
             </button>
           </div>
         </div>
+      )}
+
+      {collectionModal && createPortal(
+        <>
+          <div
+            className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm"
+            style={{ zIndex: 400 }}
+            onClick={() => setCollectionModal(null)}
+          />
+          <div
+            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] max-w-3xl max-h-[85vh] rounded-[28px] border border-[var(--modal-border)] bg-[var(--modal-bg)] text-[var(--text-primary)] shadow-2xl overflow-hidden flex flex-col"
+            style={{ zIndex: 401 }}
+          >
+            <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+              <div className="flex items-center gap-2">
+                <Film size={18} />
+                <h3 className="text-base font-semibold ui-title truncate max-w-[70%]">{collectionModal.title}</h3>
+                {!collectionModal.loading && (
+                  <span className="text-xs text-slate-400">{collectionModal.files.length} 部</span>
+                )}
+              </div>
+              <button
+                onClick={() => setCollectionModal(null)}
+                className="text-slate-400 hover:text-slate-600 transition-colors text-xl leading-none"
+              >
+                ×
+              </button>
+            </div>
+            <div className="overflow-y-auto p-6">
+              {collectionModal.loading ? (
+                <div className="text-center py-16 text-slate-400 text-sm">加载中…</div>
+              ) : (
+                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-4">
+                  {collectionModal.files.map((file, idx) => (
+                    <div key={idx} className="flex flex-col">
+                      <div className="aspect-[2/3] rounded-xl overflow-hidden bg-slate-100 border border-slate-200">
+                        {file.matched && file.posterPath ? (
+                          <img
+                            src={file.posterPath.replace('/w500', '/w185')}
+                            alt={file.title}
+                            className="w-full h-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-slate-300">
+                            <Film size={28} />
+                          </div>
+                        )}
+                      </div>
+                      <div className="mt-1.5">
+                        <p className="text-xs font-medium ui-title truncate" title={file.title}>
+                          {file.title || file.name}
+                        </p>
+                        <div className="flex items-center gap-1 mt-0.5">
+                          {file.year && <span className="text-[10px] text-slate-400">{file.year}</span>}
+                          <span className={`text-[10px] px-1 rounded ${file.matched ? 'bg-emerald-50 text-emerald-600' : 'bg-slate-100 text-slate-400'}`}>
+                            {file.matched ? '已匹配' : '未匹配'}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </>,
+        document.body
       )}
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@netdrive-sdk/log": "1.0.0",
+    "anitomy-ng": "^1.0.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -21,6 +22,7 @@
     "node-cron": "^3.0.2",
     "node-telegram-bot-api": "^0.66.0",
     "node-unrar-js": "2.0.2",
+    "nunjucks": "^3.2.4",
     "reflect-metadata": "^0.1.13",
     "session-file-store": "^1.5.0",
     "sqlite3": "^5.1.6",

--- a/scripts/run-dev-50001.sh
+++ b/scripts/run-dev-50001.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=/root/cloud189-auto-save
+LOG=$ROOT/logs/dev-50001.log
+PIDFILE=$ROOT/logs/dev-50001.pid
+
+mkdir -p "$ROOT/logs"
+ln -sfn /opt/cloud189/data "$ROOT/data"
+ln -sfn /opt/cloud189/strm "$ROOT/strm"
+ln -sfn /opt/cloud189/strm /root/strm
+
+if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+  echo "already running pid=$(cat "$PIDFILE")"
+  exit 0
+fi
+
+if ss -lntp | grep -q ':50001'; then
+  fuser -k 50001/tcp 2>/dev/null || true
+  sleep 1
+fi
+
+cd "$ROOT"
+setsid env \
+  PORT=50001 \
+  EMBY_PROXY_PORT=50004 \
+  PUID=0 \
+  PGID=0 \
+  DNS_LOOKUP_IP_VERSION=ipv4 \
+  PUBLIC_BASE_URL=http://192.168.23.161:50001 \
+  NODE_ENV=production \
+  node "$ROOT/dist/index.js" \
+  >"$LOG" 2>&1 < /dev/null &
+echo $! >"$PIDFILE"
+sleep 2
+ss -lntp | grep 50001 || { echo 'bind failed'; tail -n 50 "$LOG"; exit 1; }
+echo "started pid=$(cat "$PIDFILE") -> http://0.0.0.0:50001"

--- a/scripts/validate-specials.mjs
+++ b/scripts/validate-specials.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * 特别篇检测验证脚本：用 CloudSaver 搜索 20 个剧，创建懒转存任务，验证 STRM 输出。
+ * 用法: node scripts/validate-specials.mjs
+ * 前提: 服务运行在 localhost:3000，CloudSaver 已配置
+ */
+
+import { execSync } from 'child_process';
+
+const BASE = process.env.CLOUD189_BASE_URL || 'http://localhost:3000';
+const API_KEY = process.env.CLOUD189_API_KEY || '';
+const STRM_ROOT = process.env.CLOUD189_STRM_ROOT || '/opt/cloud189/strm';
+if (!API_KEY) {
+    console.error('请设置环境变量 CLOUD189_API_KEY（服务配置 system.apiKey）');
+    process.exit(1);
+}
+const HEADERS = { 'x-api-key': API_KEY, 'Content-Type': 'application/json' };
+const POLL_INTERVAL = 5000; // 5s
+const POLL_TIMEOUT = 90000; // 90s — 懒转存任务不会变 completed，改为等 STRM 出现
+
+const ANIME = [
+    '86不存在的战区', '弦音 风舞高中弓道部', 'WIXOSS DIVA', '无职转生',
+    '葬送的芙莉莲', '咒术回战', '间谍过家家', '紫罗兰永恒花园',
+    '进击的巨人', '鬼灭之刃'
+];
+const DRAMAS = [
+    '庆余年', '狂飙', '三体', '漫长的季节', '繁花',
+    '与凤行', '墨雨云间', '长相思', '凡人歌', '庶民样本'
+];
+
+async function api(path, opts = {}) {
+    const res = await fetch(`${BASE}${path}`, { headers: HEADERS, ...opts });
+    return res.json();
+}
+
+async function searchCloudSaver(keyword) {
+    const data = await api(`/api/cloudsaver/search?keyword=${encodeURIComponent(keyword)}&mode=list`);
+    if (!data.success || !Array.isArray(data.data)) return null;
+    // 找第一个有天翼链接的结果
+    for (const item of data.data) {
+        const link = (item.cloudLinks || []).find(l => l.link?.includes('cloud.189.cn'));
+        if (link) return { title: item.title, link: link.link, accessCode: link.accessCode || '' };
+    }
+    return null;
+}
+
+async function getAccountId() {
+    const data = await api('/api/accounts');
+    if (!data.success || !data.data?.length) throw new Error('无可用账号');
+    return data.data[0].id;
+}
+
+async function getTargetFolderId(accountId) {
+    // emby 目录 ID（已知）
+    return '723831240465883674';
+}
+
+async function createTask(accountId, targetFolderId, shareLink, accessCode, title) {
+    const body = {
+        accountId,
+        shareLink,
+        accessCode,
+        targetFolderId,
+        taskName: title,
+        enableOrganizer: true,
+        enableLazyStrm: true,
+        enableCron: false,
+        taskGroup: '验证测试',
+        remark: 'validate-specials 自动创建'
+    };
+    const data = await api('/api/tasks', { method: 'POST', body: JSON.stringify(body) });
+    if (!data.success) return { error: data.error };
+    const tasks = data.data || [];
+    return tasks.map(t => ({ id: t.id, name: t.resourceName }));
+}
+
+async function pollTask(taskId, taskName) {
+    const start = Date.now();
+    while (Date.now() - start < POLL_TIMEOUT) {
+        // 查任务状态，拿到实际 resourceName 和 layout
+        const data = await api('/api/tasks');
+        const task = (data.data || []).find(t => t.id === taskId);
+        if (task?.status === 'failed') {
+            return { status: 'failed', error: task.lastError };
+        }
+        // 用任务的实际名称（organizer 产出的 canonical title）查 STRM
+        const actualName = task?.resourceName || taskName;
+        const strm = checkStrmTree(actualName);
+        if (strm.found && (strm.season00.length + strm.season01.length + strm.other.length) > 0) {
+            return { status: 'strm_ready', strm, actualName };
+        }
+        await new Promise(r => setTimeout(r, POLL_INTERVAL));
+    }
+    return { status: 'timeout' };
+}
+
+function checkStrmTree(taskName) {
+    try {
+        const dirs = execSync(
+            `find "${STRM_ROOT}" -maxdepth 3 -type d -name '*${taskName.replace(/'/g, '')}*' 2>/dev/null`,
+            { encoding: 'utf8' }
+        ).trim().split('\n').filter(Boolean);
+        if (!dirs.length) return { found: false };
+
+        const result = { found: true, season00: [], season01: [], other: [] };
+        for (const dir of dirs) {
+            const strms = execSync(
+                `find "${dir}" -name '*.strm' 2>/dev/null`,
+                { encoding: 'utf8' }
+            ).trim().split('\n').filter(Boolean);
+            for (const s of strms) {
+                if (s.includes('Season 00')) result.season00.push(s.split('/').pop());
+                else if (s.includes('Season 01')) result.season01.push(s.split('/').pop());
+                else result.other.push(s.split('/').pop());
+            }
+        }
+        return result;
+    } catch {
+        return { found: false };
+    }
+}
+
+async function main() {
+    console.log('=== 特别篇检测验证 ===\n');
+
+    const accountId = await getAccountId();
+    const targetFolderId = await getTargetFolderId(accountId);
+    console.log(`账号: ${accountId}, 目标目录: ${targetFolderId}\n`);
+
+    const results = [];
+    const createdTaskIds = [];
+
+    for (const category of [['日漫', ANIME], ['国产剧', DRAMAS]]) {
+        const [label, titles] = category;
+        console.log(`\n--- ${label} ---`);
+
+        for (const title of titles) {
+            process.stdout.write(`  ${title}: `);
+
+            // 1. 搜索
+            const resource = await searchCloudSaver(title);
+            if (!resource) {
+                console.log('⏭ 无天翼源，跳过');
+                results.push({ title, label, verdict: 'SKIP', reason: '无天翼源' });
+                continue;
+            }
+
+            // 2. 创建任务
+            const tasks = await createTask(accountId, targetFolderId, resource.link, resource.accessCode, title);
+            if (tasks.error) {
+                console.log(`❌ 创建失败: ${tasks.error}`);
+                results.push({ title, label, verdict: 'FAIL', reason: tasks.error });
+                continue;
+            }
+
+            // 3. 等待 STRM 生成
+            for (const task of tasks) {
+                createdTaskIds.push(task.id);
+                const poll = await pollTask(task.id, task.name || title);
+                const strm = poll.strm || checkStrmTree(task.name || title);
+
+                let verdict = 'OK';
+                let detail = '';
+
+                if (poll.status === 'timeout') {
+                    verdict = 'TIMEOUT';
+                } else if (poll.status === 'failed') {
+                    verdict = 'FAIL';
+                    detail = poll.error || '';
+                } else if (!strm.found) {
+                    verdict = 'WARN';
+                    detail = 'STRM 目录未找到';
+                } else {
+                    const s00 = strm.season00.length;
+                    const s01 = strm.season01.length;
+                    const other = strm.other.length;
+                    detail = `S00:${s00} S01:${s01} 其他:${other}`;
+
+                    if (label === '国产剧' && s00 > 0) {
+                        verdict = 'WARN';
+                        detail += ' (国产剧不应有 S00)';
+                    }
+                }
+
+                const icon = verdict === 'OK' ? '✓' : verdict === 'WARN' ? '⚠' : verdict === 'SKIP' ? '⏭' : '❌';
+                console.log(`${icon} ${verdict} ${detail}`);
+                results.push({ title, label, verdict, reason: detail, taskId: task.id });
+            }
+        }
+    }
+
+    // 汇总
+    console.log('\n=== 汇总 ===');
+    console.log('标题 | 类型 | 结果 | 详情');
+    console.log('---|---|---|---');
+    for (const r of results) {
+        console.log(`${r.title} | ${r.label} | ${r.verdict} | ${r.reason || ''}`);
+    }
+
+    const ok = results.filter(r => r.verdict === 'OK').length;
+    const warn = results.filter(r => r.verdict === 'WARN').length;
+    const fail = results.filter(r => r.verdict === 'FAIL').length;
+    const skip = results.filter(r => r.verdict === 'SKIP').length;
+    console.log(`\n总计: ${ok} OK, ${warn} WARN, ${fail} FAIL, ${skip} SKIP`);
+
+    // 清理提示
+    if (createdTaskIds.length) {
+        console.log(`\n清理: 删除 ${createdTaskIds.length} 个测试任务`);
+        console.log(`  curl -X DELETE -H 'x-api-key: ${API_KEY}' -H 'Content-Type: application/json' \\`);
+        console.log(`    -d '{"taskIds":[${createdTaskIds.join(',')}],"deleteCloud":true}' \\`);
+        console.log(`    ${BASE}/api/tasks/batch`);
+    }
+}
+
+main().catch(e => { console.error('Fatal:', e.message); process.exit(1); });

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const { CasService } = require('./services/casService');
 const { CasImportService } = require('./services/casImportService');
 const { DoubanService } = require('./services/douban');
 const multer = require('multer');
+const { validateLazyFileCleanupSettings } = require('./utils/settingsValidation');
 
 const appPort = Number(process.env.PORT || 3000);
 let embyStandaloneProxyServer = null;
@@ -1584,6 +1585,13 @@ AppDataSource.initialize().then(async () => {
             if (task.account) {
                 task.account.accountType = task.account.accountType || 'personal';
             }
+            // 电影合集标记：供前端展示「合集详情」入口
+            let isCollection = false;
+            try {
+                const layout = task.libraryLayout ? JSON.parse(task.libraryLayout) : null;
+                isCollection = layout?.mediaType === 'movie' && Array.isArray(layout.files) && layout.files.length > 1;
+            } catch (_) {}
+            task.isCollection = isCollection;
         });
         res.json({
             success: true,
@@ -1755,6 +1763,31 @@ AppDataSource.initialize().then(async () => {
         try {
             const result = await taskService.bindManualTmdb(parseInt(req.params.id), req.body || {});
             res.json({ success: true, data: result });
+        } catch (error) {
+            res.json({ success: false, error: error.message });
+        }
+    });
+
+    // 电影合集逐文件 TMDB 数据（供前端展示合集详情）
+    app.get('/api/tasks/:id/collection-files', async (req, res) => {
+        try {
+            const task = await taskRepo.findOne({ where: { id: parseInt(req.params.id) } });
+            if (!task) throw new Error('任务不存在');
+            let layout = null;
+            try { layout = task.libraryLayout ? JSON.parse(task.libraryLayout) : null; } catch (_) {}
+            const isCollection = layout?.mediaType === 'movie' && Array.isArray(layout.files) && layout.files.length > 1;
+            if (!isCollection) {
+                return res.json({ success: true, data: { isCollection: false, files: [] } });
+            }
+            const files = layout.files.map((f) => ({
+                name: f.name || '',
+                title: f.tmdbTitle || f.name || '',
+                year: f.year || '',
+                tmdbId: f.tmdbId || '',
+                posterPath: f.posterPath || '',
+                matched: !!f.tmdbId
+            }));
+            res.json({ success: true, data: { isCollection: true, files } });
         } catch (error) {
             res.json({ success: false, error: error.message });
         }
@@ -2484,25 +2517,34 @@ AppDataSource.initialize().then(async () => {
     })
 
     app.post('/api/settings', async (req, res) => {
-        const settings = preserveSensitiveOnEmptyInput(
-            await prepareSettingsForSave(normalizeTelegramSettings(req.body))
-        );
-        SchedulerService.handleScheduleTasks(settings,taskService);
-        ConfigService.setConfig(settings)
-        await botManager.handleBotStatus(
-            settings.telegram?.bot?.botToken,
-            settings.telegram?.bot?.chatId,
-            settings.telegram?.bot?.enable,
-            {
-                allowedChatIds: settings.telegram?.bot?.allowedChatIds || [],
-                adminChatIds: settings.telegram?.bot?.adminChatIds || [],
+        try {
+            const settings = preserveSensitiveOnEmptyInput(
+                await prepareSettingsForSave(normalizeTelegramSettings(req.body))
+            );
+            const validationError = validateLazyFileCleanupSettings(settings);
+            if (validationError) {
+                return res.status(400).json({ success: false, error: validationError });
             }
-        );
-        // 修改配置, 重新实例化消息推送
-        messageUtil.updateConfig()
-        Cloud189Service.setProxy()
-        await embyPrewarmService.reload();
-        res.json({success: true, data: null})
+
+            SchedulerService.handleScheduleTasks(settings,taskService);
+            ConfigService.setConfig(settings)
+            await botManager.handleBotStatus(
+                settings.telegram?.bot?.botToken,
+                settings.telegram?.bot?.chatId,
+                settings.telegram?.bot?.enable,
+                {
+                    allowedChatIds: settings.telegram?.bot?.allowedChatIds || [],
+                    adminChatIds: settings.telegram?.bot?.adminChatIds || [],
+                }
+            );
+            // 修改配置, 重新实例化消息推送
+            messageUtil.updateConfig()
+            Cloud189Service.setProxy()
+            await embyPrewarmService.reload();
+            res.json({success: true, data: null})
+        } catch (error) {
+            res.status(400).json({ success: false, error: error.message || '保存设置失败' });
+        }
     })
 
     app.post('/api/settings/telegram/test', async (req, res) => {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>天翼云盘自动转存系统</title>
-    <script type="module" crossorigin src="/assets/index-BOLlwlpa.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DR9wKSv0.css">
+    <script type="module" crossorigin src="/assets/index-FRvcZOhh.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BD7aYJLM.css">
   </head>
   <body>
     <div id="root"></div>
   </body>
 </html>
+

--- a/src/services/ConfigService.js
+++ b/src/services/ConfigService.js
@@ -212,8 +212,8 @@ class ConfigService {
         model: 'GLM-4-Flash-250414',
         flowControlEnabled: false,
         rename: {
-          template: "{name} - {se}{ext}",  // 默认模板
-          movieTemplate: "{name} ({year}){ext}",  // 电影模板
+          template: "{{name}} - {{se}}{{ext}}",  // 默认模板（nunjucks）
+          movieTemplate: "{{name}}{% if year %} ({{year}}){% endif %}{{ext}}",  // 电影模板（年份为空时省括号）
         }
       },
       alist: {

--- a/src/services/ScrapeService.js
+++ b/src/services/ScrapeService.js
@@ -16,7 +16,11 @@ class ScrapeService {
         this.scraped = false;
     }
 
-    async scrapeFromDirectory(dirPath, tmdbId = null) {
+    async scrapeFromDirectory(dirPath, tmdbId = null, collectionFiles = null) {
+        // 电影合集：逐文件独立刮削（每个文件有自己的 tmdbId）
+        if (Array.isArray(collectionFiles) && collectionFiles.length > 1) {
+            return await this._scrapeCollection(dirPath, collectionFiles);
+        }
         if (this.ai.isEnabled()) {
             logTaskEvent('使用AI进行刮削');
             return await this.scrapeWithAI(dirPath, tmdbId);
@@ -192,6 +196,93 @@ class ScrapeService {
 
         } catch (error) {
             logTaskEvent('AI刮削失败: ' + error.message);
+            return null;
+        }
+    }
+
+    /**
+     * 电影合集逐文件刮削：每个 STRM 文件匹配自己的 TMDB 条目，
+     * 生成独立的 {基础名}.nfo + {基础名}-poster.jpg，使 Emby 把每部识别为独立电影。
+     * @param {string} dirPath 合集 STRM 目录
+     * @param {Array<{name:string, tmdbId:string}>} collectionFiles 布局层的逐文件 TMDB 数据
+     */
+    async _scrapeCollection(dirPath, collectionFiles) {
+        try {
+            const strmFiles = await this._getStrmFiles(dirPath);
+            if (strmFiles.length === 0) {
+                logTaskEvent('合集目录中没有可刮削文件');
+                return null;
+            }
+            const parsedPath = this._parseStrmPath(path.join(dirPath, strmFiles[0]));
+            const showDir = parsedPath.showDir;
+
+            const availableEntries = collectionFiles.map((entry, index) => ({ entry, index, used: false }));
+            const normalizeTitle = (value) => String(value || '')
+                .normalize('NFKC')
+                .replace(/\((19|20)\d{2}\)/g, ' ')
+                .replace(/[^\p{L}\p{N}]+/gu, ' ')
+                .replace(/\s+/g, ' ')
+                .trim()
+                .toLowerCase();
+            const pickEntry = (strmFile, sortedIndex) => {
+                const baseName = path.parse(strmFile).name; // 如 "Detective Conan Movie10 ... (2006)"
+                const yearMatch = baseName.match(/\((\d{4})\)/);
+                const fileYear = yearMatch ? yearMatch[1] : '';
+                const normalizedBase = normalizeTitle(baseName);
+                let matched = availableEntries.find(({ entry, used }) =>
+                    !used && entry.organizedFileName
+                    && normalizeTitle(path.parse(entry.organizedFileName).name) === normalizedBase
+                );
+                if (!matched) {
+                    matched = availableEntries.find(({ entry, used }) =>
+                        !used
+                        && (!fileYear || String(entry.year || '') === fileYear)
+                        && normalizeTitle(entry.name) === normalizedBase
+                    );
+                }
+                if (!matched && fileYear) {
+                    const sameYear = availableEntries.filter(({ entry, used }) => !used && String(entry.year || '') === fileYear);
+                    if (sameYear.length === 1) matched = sameYear[0];
+                }
+                if (!matched) {
+                    matched = availableEntries.find(({ used, index }) => !used && index === sortedIndex)
+                        || availableEntries.find(({ used }) => !used);
+                }
+                if (matched) matched.used = true;
+                return matched?.entry || null;
+            };
+
+            let scraped = 0, skipped = 0;
+            const sortedStrmFiles = [...strmFiles].sort((a, b) =>
+                a.localeCompare(b, 'zh-CN', { numeric: true, sensitivity: 'base' })
+            );
+            for (const [index, strmFile] of sortedStrmFiles.entries()) {
+                const baseName = path.parse(strmFile).name;
+                const entry = pickEntry(strmFile, index);
+                if (!entry || !entry.tmdbId) {
+                    skipped++;
+                    continue;
+                }
+                try {
+                    const detail = await this.tmdb.getMovieDetails(entry.tmdbId);
+                    if (!detail?.id) { skipped++; continue; }
+                    const nfoPath = path.join(showDir, `${baseName}.nfo`);
+                    const posterPath = path.join(showDir, `${baseName}-poster.jpg`);
+                    await Promise.all([
+                        this._generateFileIfNotExists(nfoPath, () => this._generateMovieNFO(detail)),
+                        this._generateFileIfNotExists(posterPath, () => this._downloadImage(detail.posterPath))
+                    ]);
+                    scraped++;
+                } catch (error) {
+                    logTaskEvent(`合集文件刮削失败「${baseName}」: ${error.message}`);
+                    skipped++;
+                }
+            }
+            logTaskEvent(`合集刮削完成: 成功 ${scraped}, 跳过 ${skipped}`);
+            this.scraped = scraped > 0;
+            return { type: 'movie', collection: true, scraped, skipped };
+        } catch (error) {
+            logTaskEvent('合集刮削失败: ' + error.message);
             return null;
         }
     }

--- a/src/services/ai.js
+++ b/src/services/ai.js
@@ -259,6 +259,8 @@ class AIService {
                             3. 如果无法确定年份，返回0, 如果无法确定季编号, 返回01
                             4. 如果无法判断类型，默认为 movie
                             5. 如果是单个文件，episode 数组只包含一个元素
+                            6. 多部独立电影组成的合集（标题含"剧场版""电影""Movie"，或各文件有独立片名和不同年份）应判为 movie；此时 episode 数组中每个条目必须填写该文件自己的片名（name）和年份（year），而不是合集的统一标题
+                            7. 特殊季文件（如 NCOP/NCED 无字幕片头片尾、OVA、SP 特别篇等非正片内容），season 必须设为 "00"（Emby 特别篇），episode 按顺序编号，不要占用正片集号
 
                             返回格式必须是: {
                                 name: string,  // 纯净的影视剧名称，不含年份
@@ -268,6 +270,7 @@ class AIService {
                                 episode: [{ // 仅包含当前处理的 chunk 的剧集信息
                                     id: string,
                                     name: string, // 使用父级目录中提取到的纯净的影视剧名称，不含年份
+                                    year: number, // 该文件自己的年份；电影合集时各文件年份不同，剧集时可省略
                                     season: string,  // 季编号，必须是纯数字字符串，如："01"
                                     episode: string,  // 集编号，如果小于100使用两位数字（如："01"），大于等于100使用实际位数
                                     extension: string
@@ -305,11 +308,14 @@ class AIService {
                             类型: ${baseResult.type}
                             季编号: ${baseResult.season || 'N/A'} // 提供季编号上下文
 
+                            如果类型是 movie 且文件列表包含多部独立电影，每个条目必须保留该文件自己的 name 和 year，不能统一成合集名称。
+
                             返回格式必须是**严格的 JSON 对象**，包含一个 'episode' 键，其值为一个数组。数组中的每个对象代表一个剧集信息。**确保所有键（如 "id", "name", "season", "episode", "extension"）都用双引号括起来**：
                             {
                                 "episode": [{ // 仅包含当前处理的 chunk 的剧集信息
                                     "id": "string",
                                     "name": "${baseResult.name}", // 使用上面提供的影视剧名称，不能包含年份
+                                    "year": ${baseResult.year || 0}, // movie 合集填写该文件自己的年份
                                     "season": "${baseResult.season || ''}",  // 使用上面提供的季编号 (确保是字符串)
                                     "episode": "string",  // 集编号，如果小于100使用两位数字（如："01"），大于等于100使用实际位数
                                     "extension": "string"
@@ -324,7 +330,8 @@ class AIService {
                             3. **必须严格按照上述 JSON 格式返回，确保所有键和字符串值都使用双引号。**
                             4. 必须严格按照此格式返回，不要添加任何额外说明文字。
                             5. 不要使用代码块标记，直接返回 JSON 对象
-                            6. 只需要返回 'episode' 字段。`
+                            6. 只需要返回 'episode' 字段。
+                            7. 特殊季文件（如 NCOP/NCED 无字幕片头片尾、OVA、SP 特别篇等非正片内容），season 必须设为 "00"（Emby 特别篇），episode 按顺序编号，不要占用正片集号`
                         },
                         {
                             role: 'user',
@@ -364,12 +371,21 @@ class AIService {
                     };
                     allEpisodes.push(...resultChunk.episode);
                 } else {
-                    // 对于后续块，确保 episode 里的 name 和 season 与 baseResult 一致
-                    const correctedEpisodes = resultChunk.episode.map(ep => ({
-                        ...ep,
-                        name: baseResult.name, // 强制使用基础名称
-                        season: baseResult.season // 强制使用基础季编号
-                    }));
+                    // 后续块：电视剧统一作品名，电影合集保留逐文件片名/年份；
+                    // season 始终保留 AI 的逐文件结果，避免把特别篇塞回正片季。
+                    const preserveMovieMetadata = baseResult.type === 'movie' && files.length > 1;
+                    const correctedEpisodes = resultChunk.episode.map(ep => {
+                        const rawSeason = String(ep.season ?? '').trim();
+                        const season = /^\d+$/.test(rawSeason)
+                            ? rawSeason.padStart(2, '0')
+                            : baseResult.season;
+                        return {
+                            ...ep,
+                            name: preserveMovieMetadata ? (ep.name || baseResult.name) : baseResult.name,
+                            ...(preserveMovieMetadata && ep.year == null ? { year: baseResult.year } : {}),
+                            season
+                        };
+                    });
                     allEpisodes.push(...correctedEpisodes);
                 }
             }
@@ -628,6 +644,62 @@ class AIService {
         }
 
         return true;
+    }
+
+    /**
+     * 判断一个多文件资源是否为"多部独立电影组成的合集"。
+     * 独立于 simpleChatCompletion（那个负责解析文件名/季集），这里只回答"是不是合集"。
+     * @param {string} resourceName 原始资源标题（可能不规范）
+     * @param {Array<{name?:string}>} files 文件名列表
+     * @returns {Promise<{isCollection:boolean, reason:string}|null>} 失败返回 null（调用方走确定性 fallback）
+     */
+    async detectCollectionWithAI(resourceName, files = []) {
+        const openaiConfig = ConfigService.getConfigValue('openai');
+        if (!this.isEnabled(openaiConfig)) {
+            return null;
+        }
+        const fileList = (files || [])
+            .map((f) => f.name || f.restoreName || '')
+            .filter(Boolean)
+            .slice(0, 30);
+        if (fileList.length < 2) {
+            return { isCollection: false, reason: '文件数不足' };
+        }
+        const messages = [
+            {
+                role: 'system',
+                content: `你是一个影视资源分类助手。判断给定资源是否为"多部独立电影组成的合集"（如"名侦探柯南剧场版01-26合集"，里面是 26 部各自独立的电影）。
+
+判断要点：
+1. 合集特征：各文件是独立影片（片名不同、上映年份各不相同），标题常含"合集/剧场版/电影/Movie/系列/Collection"。
+2.剧集特征：各文件是同一部剧的不同集（文件名含 S01E01、第x集、EP01，或仅以集号区分，年份相同或无年份）。
+3. 即使标题含"电影"字样，若文件表现为剧集（同一年份、按集编号），也应判为非合集。
+
+严格返回 JSON 对象，不要代码块，不要说明文字：
+{ "isCollection": boolean, "reason": string }`
+            },
+            {
+                role: 'user',
+                content: `资源标题：${resourceName || '(无)'}\n文件列表：\n${fileList.map((n, i) => `${i + 1}. ${n}`).join('\n')}`
+            }
+        ];
+
+        try {
+            return await this._retryOperation('AI合集判定', async () => {
+                const response = await this.chat(messages, { temperature: 0, max_tokens: 300 });
+                if (!response.success) {
+                    throw new Error(response.error || 'AI 调用失败');
+                }
+                const parsed = JSON.parse(this._getCleanAIJsonText(response.data));
+                return {
+                    isCollection: !!parsed.isCollection,
+                    reason: String(parsed.reason || '')
+                };
+            });
+        } catch (error) {
+            logTaskEvent(`[Layout] AI 合集判定失败，回退确定性规则: ${error.message}`);
+            return null;
+        }
     }
 }
 

--- a/src/services/autoSeries.js
+++ b/src/services/autoSeries.js
@@ -230,9 +230,7 @@ class AutoSeriesService {
             keepCasAfterRestore: Boolean(keepCasAfterRestore)
         });
 
-        for (const task of tasks || []) {
-            await this.taskService.processTask(task);
-        }
+        // createTask 内部已异步触发首次执行，这里不再阻塞等待
 
         return {
             taskCount: tasks?.length || 0,
@@ -287,9 +285,7 @@ class AutoSeriesService {
             keepCasAfterRestore: Boolean(keepCasAfterRestore)
         });
 
-        for (const task of tasks || []) {
-            await this.taskService.processTask(task);
-        }
+        // createTask 内部已异步触发首次执行，这里不再阻塞等待
 
         return {
             taskCount: tasks?.length || 0,

--- a/src/services/cloud189.js
+++ b/src/services/cloud189.js
@@ -783,11 +783,13 @@ class Cloud189Service {
                     familyId
                 },
             });
-            const url = response?.fileDownloadUrl;
+            let url = response?.fileDownloadUrl;
             if (!url) {
                 throw new Error(response?.res_msg || '获取家庭云直链失败');
             }
-            const res = await got(String(url).replace('http://', 'https://'), {
+            // 天翼 API 返回的 URL 里 & 被 HTML 转义成 &amp;，必须还原否则参数全乱 → 403
+            url = String(url).replace(/&amp;/g, '&').replace('http://', 'https://');
+            const res = await got(url, {
                 followRedirect: false,
                 headers: {
                     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0'

--- a/src/services/mediaLibraryLayout.js
+++ b/src/services/mediaLibraryLayout.js
@@ -11,10 +11,12 @@ const fsp = require('fs').promises;
 const path = require('path');
 const crypto = require('crypto');
 const ConfigService = require('./ConfigService');
-const { parseMediaTitle } = require('../utils/mediaTitleParser');
+const { parseMediaTitle, detectMovieCollection, resolveTitleMeta } = require('../utils/mediaTitleParser');
+const { renderFileName } = require('../utils/templateRenderer');
 const { logTaskEvent } = require('../utils/logUtils');
+const AIService = require('./ai');
 
-const PROMPT_VERSION = 'v1';
+const PROMPT_VERSION = 'v2';
 
 function normalizeRelativePath(value = '') {
     return String(value || '')
@@ -45,11 +47,22 @@ function extractYear(value = '') {
 }
 
 function pad2(value) {
-    const num = parseInt(String(value || ''), 10);
-    if (!Number.isFinite(num) || num <= 0) {
+    const num = parseInt(String(value ?? ''), 10);
+    if (!Number.isFinite(num) || num < 0) {
         return '01';
     }
     return String(num).padStart(2, '0');
+}
+
+/**
+ * 特别篇确定性兜底检测（NCOP/NCED/SP/Non-Credit）。
+ * 全仓库唯一入口——AI 是主检测器，此函数仅作安全网；禁止再复制这份正则。
+ * 故意不收 OVA/OAD：那类形态交给 AI 判定，兜底只覆盖最高频的字面模式以保持零回归。
+ */
+const SPECIAL_FILE_PATTERNS = [/\bNC(OP|ED|IN)/i, /\bSP\d/i, /Non-Credit/i, /\[\d+\.5\]/];
+function isSpecialEpisodeName(name = '') {
+    const text = String(name || '');
+    return !!text && SPECIAL_FILE_PATTERNS.some((re) => re.test(text));
 }
 
 function joinPosix(...parts) {
@@ -148,7 +161,12 @@ class MediaLibraryLayoutService {
             resourceFolderName,
             seasonBased: mediaType !== 'movie',
             tmdbId: info.tmdbId ? String(info.tmdbId) : (info.id ? String(info.id) : ''),
-            locked: info.locked !== false
+            locked: info.locked !== false,
+            // 默认季号：目录名/任务名解析出的季号（如"第二季"→"02"），
+            // 序列化后保留，供 buildRelativeDir 在无 aiFile 时做最终 fallback。
+            ...(info.defaultSeason ? { defaultSeason: String(info.defaultSeason) } : {}),
+            // 电影合集逐文件 TMDB 数据（非合集为 undefined，不影响现有序列化）
+            ...(Array.isArray(info.files) && info.files.length ? { files: info.files } : {})
         };
     }
 
@@ -179,14 +197,17 @@ class MediaLibraryLayoutService {
         if (!info.seasonBased) {
             return '';
         }
-        if (aiFile) {
-            const seasonValue = String(aiFile.season || '').trim();
-            if (/^\d+$/.test(seasonValue)) {
-                return `Season ${seasonValue.padStart(2, '0')}`;
-            }
-            if (seasonValue) {
-                return sanitizePathSegment(seasonValue);
-            }
+        // 并集语义：AI 判为 S00（覆盖 OVA/PV 等正则不认识的形式）或确定性兜底命中（防 AI 漏判 NCOP）→ Season 00
+        const originalName = file.originalFileName || file.restoreName || file.name || '';
+        const aiSeasonRaw = String(aiFile?.season || '').trim();
+        const aiSeasonDir = /^\d+$/.test(aiSeasonRaw)
+            ? `Season ${aiSeasonRaw.padStart(2, '0')}`
+            : (aiSeasonRaw ? sanitizePathSegment(aiSeasonRaw) : null);
+        if (aiSeasonDir === 'Season 00' || isSpecialEpisodeName(originalName)) {
+            return 'Season 00';
+        }
+        if (aiSeasonDir) {
+            return aiSeasonDir;
         }
         const relativeDir = normalizeRelativePath(file.relativeDir || '');
         const parts = relativeDir ? relativeDir.split('/').filter(Boolean) : [];
@@ -202,19 +223,24 @@ class MediaLibraryLayoutService {
         if (parsed.season != null) {
             return `Season ${pad2(parsed.season)}`;
         }
-        return 'Season 01';
+        // 最终 fallback：用 layout 里保留的默认季号（如"第二季"→"02"），否则 Season 01
+        return info.defaultSeason ? `Season ${info.defaultSeason}` : 'Season 01';
     }
 
     buildFileName(file, aiFile, resourceInfo, libraryInfo) {
         const info = this.normalizeLibraryInfo(libraryInfo || {});
         const isMovie = (resourceInfo?.type || info.mediaType) === 'movie';
         const template = isMovie
-            ? (ConfigService.getConfigValue('openai.rename.movieTemplate') || '{name} ({year}){ext}')
-            : (ConfigService.getConfigValue('openai.rename.template') || '{name} - {se}{ext}');
+            ? (ConfigService.getConfigValue('openai.rename.movieTemplate') || '{{name}}{% if year %} ({{year}}){% endif %}{{ext}}')
+            : (ConfigService.getConfigValue('openai.rename.template') || '{{name}} - {{se}}{{ext}}');
 
         const name = aiFile?.name || info.canonicalTitle || resourceInfo?.name || sanitizeTitle(file.name);
-        const year = String(resourceInfo?.year || info.year || '');
-        const season = pad2(aiFile?.season || '01');
+        // 电影合集场景每个文件带独立年份（aiFile.year），优先于合集级年份
+        const year = String(aiFile?.year || resourceInfo?.year || info.year || '');
+        // 并集语义：AI 判为 S00 或确定性兜底命中 → Season 00，与 buildRelativeDir 保持一致
+        const originalName = file.originalFileName || file.restoreName || file.name || '';
+        const aiSeason = pad2(aiFile?.season || info.defaultSeason || '01');
+        const season = (aiSeason === '00' || isSpecialEpisodeName(originalName)) ? '00' : aiSeason;
         const episode = (() => {
             const raw = String(aiFile?.episode || '01');
             const num = parseInt(raw, 10);
@@ -222,20 +248,17 @@ class MediaLibraryLayoutService {
             return num >= 100 ? String(num) : String(num).padStart(2, '0');
         })();
         const ext = aiFile?.extension || path.extname(file.name || file.restoreName || '') || '';
-        const replaceMap = {
-            '{name}': name,
-            '{year}': year,
-            '{s}': season,
-            '{e}': episode,
-            '{sn}': String(parseInt(season, 10) || 1),
-            '{en}': String(parseInt(episode, 10) || 1),
-            '{ext}': ext.startsWith('.') || !ext ? ext : `.${ext}`,
-            '{se}': `S${season}E${episode}`
+        const vars = {
+            name,
+            year,
+            s: season,
+            e: episode,
+            sn: String(parseInt(season, 10) || 1),
+            en: String(parseInt(episode, 10) || 1),
+            ext: ext.startsWith('.') || !ext ? ext : `.${ext}`,
+            se: `S${season}E${episode}`
         };
-        let newName = template;
-        for (const [key, value] of Object.entries(replaceMap)) {
-            newName = newName.replace(new RegExp(key.replace(/[{}]/g, '\\$&'), 'g'), value);
-        }
+        const newName = renderFileName(template, vars);
         return sanitizePathSegment(newName) || (file.name || file.restoreName || 'file');
     }
 
@@ -259,14 +282,6 @@ class MediaLibraryLayoutService {
             return locked;
         }
 
-        const parsedResource = parseMediaTitle(resourceName || task?.resourceName || '');
-        let resourceInfo = {
-            name: sanitizeTitle(parsedResource.cleanTitle || resourceName || task?.resourceName || '未命名') || '未命名',
-            year: parsedResource.year || extractYear(resourceName) || '',
-            type: 'tv',
-            episode: []
-        };
-
         // 确定性：从文件列表补季集
         const sortedFiles = [...(files || [])].sort((a, b) =>
             String(a.name || a.restoreName || '').localeCompare(String(b.name || b.restoreName || ''), 'zh-CN', {
@@ -275,11 +290,56 @@ class MediaLibraryLayoutService {
             })
         );
 
-        // AI（可选，带缓存）
+        // 标题层级补全：文件名（最精确）→ 选中目录名 → 父级标题。
+        // title 取中文来源（适合做文件夹名），year/season/episode 取文件名优先。
+        const titleMeta = resolveTitleMeta(
+            { resourceName: resourceName || task?.resourceName || '', shareFolderName: task?.shareFolderName || '' },
+            sortedFiles
+        );
+        // 源文件名解析标题（英文规范命名），用于 TMDB 搜索主候选
+        const firstFileParsed = sortedFiles.length
+            ? parseMediaTitle(sortedFiles[0].name || sortedFiles[0].restoreName || '')
+            : null;
+        const fileSearchTitle = firstFileParsed?.cleanTitle || '';
+        const fileSearchYear = firstFileParsed?.year != null ? firstFileParsed.year : '';
+
+        let resourceInfo = {
+            name: sanitizeTitle(titleMeta.title || resourceName || task?.resourceName || '未命名') || '未命名',
+            year: titleMeta.year != null ? titleMeta.year : (extractYear(resourceName || task?.resourceName) || ''),
+            season: titleMeta.season != null ? titleMeta.season : null,
+            type: 'tv',
+            episode: []
+        };
+
+        // 电影合集判定：AI 主判（useAi 且文件数 > 1），确定性规则 fallback。
+        // 选了子目录时用子目录名判定（它才是实际内容），父级"合集"标题不代表子目录也是合集。
+        const parentTitle = resourceName || task?.resourceName || '';
+        const selectedDirName = task?.shareFolderName || '';
+        const hasSelectedSubDir = !!(selectedDirName && selectedDirName !== parentTitle);
+        const titleForDetect = hasSelectedSubDir ? selectedDirName : (parentTitle || titleMeta.title);
+        const deterministic = detectMovieCollection(titleForDetect, sortedFiles);
+        let isMovieCollection = false;
+        if (sortedFiles.length > 1) {
+            if (useAi && this.taskService) {
+                const aiVerdict = await AIService.detectCollectionWithAI(titleForDetect, sortedFiles);
+                if (aiVerdict) {
+                    isMovieCollection = aiVerdict.isCollection;
+                    logTaskEvent(`[Layout] AI 合集判定: ${isMovieCollection ? '是' : '否'}（${aiVerdict.reason}）`);
+                } else {
+                    isMovieCollection = deterministic.isMovieCollection; // AI 不可用/失败 → fallback
+                }
+            } else {
+                isMovieCollection = deterministic.isMovieCollection;
+            }
+        }
+        const collection = { isMovieCollection, perFileNames: deterministic.perFileNames };
+
+        // AI（可选，带缓存）；AI 未启用 / 返回空 / 抛错时回退到确定性规则
+        let resolvedByAi = false;
         if (useAi && this.taskService && sortedFiles.length) {
             try {
                 const aiInfo = await this._analyzeWithCache(
-                    resourceName || task?.resourceName || '',
+                    titleMeta.title || resourceName || task?.resourceName || '',
                     sortedFiles.map((f) => ({ id: String(f.id || f.entryKey || f.name), name: f.name || f.restoreName || '' }))
                 );
                 if (aiInfo?.name) {
@@ -287,38 +347,81 @@ class MediaLibraryLayoutService {
                         ...resourceInfo,
                         name: sanitizeTitle(aiInfo.name) || resourceInfo.name,
                         year: aiInfo.year || resourceInfo.year,
-                        type: aiInfo.type === 'movie' ? 'movie' : 'tv',
+                        type: isMovieCollection ? 'movie' : (aiInfo.type === 'movie' ? 'movie' : 'tv'),
                         season: aiInfo.season,
-                        episode: Array.isArray(aiInfo.episode) ? aiInfo.episode : []
+                        episode: Array.isArray(aiInfo.episode) ? aiInfo.episode : [],
+                        isMovieCollection,
+                        // 源文件名标题始终可用，供 TMDB 搜索主候选
+                        searchTitle: fileSearchTitle || undefined,
+                        searchYear: fileSearchYear || undefined
                     };
+                    resolvedByAi = true;
                 }
             } catch (error) {
                 logTaskEvent(`[Layout] AI 分析失败，使用确定性回退: ${error.message}`);
             }
-        } else if (sortedFiles.length) {
-            let hasSeasonEpisodeHint = parsedResource.season != null || parsedResource.episode != null;
-            resourceInfo.episode = sortedFiles.map((file, index) => {
-                const parsed = parseMediaTitle(file.name || file.restoreName || '');
-                if (parsed.season != null || parsed.episode != null) {
-                    hasSeasonEpisodeHint = true;
+        }
+        if (!resolvedByAi && sortedFiles.length) {
+            resourceInfo = this._buildDeterministicResourceInfo(
+                resourceInfo,
+                titleMeta.title || resourceName || task?.resourceName || '',
+                sortedFiles,
+                collection
+            );
+        }
+
+        // 后处理：无论 AI 还是确定性路径，强制把特别篇文件（NCOP/NCED/SP/Non-Credit）改到 Season 00。
+        // AI 可能不遵守 prompt 里的规则，确定性路径已内置检测但 AI 路径没有——统一兜底。
+        if (Array.isArray(resourceInfo.episode) && resourceInfo.episode.length) {
+            const fileById = new Map(sortedFiles.map((f) => [String(f.id || f.entryKey || f.name), f.name || f.restoreName || '']));
+            // 合集逐文件标题和年份以确定性文件名解析为准，避免 AI 分块后把后续电影统一成合集标题。
+            if (resourceInfo.isMovieCollection) {
+                for (const ep of resourceInfo.episode) {
+                    const fileName = fileById.get(String(ep.id)) || '';
+                    const perFile = collection.perFileNames.get(fileName);
+                    if (perFile?.title) ep.name = perFile.title;
+                    if (perFile?.year != null) ep.year = perFile.year;
                 }
-                return {
-                    id: String(file.id || file.entryKey || index),
-                    name: resourceInfo.name,
-                    season: parsed.season != null ? pad2(parsed.season) : '01',
-                    episode: parsed.episode != null
-                        ? (parsed.episode >= 100 ? String(parsed.episode) : pad2(parsed.episode))
-                        : pad2(index + 1),
-                    extension: path.extname(file.name || file.restoreName || '') || ''
-                };
-            });
-            // 单文件也可能是剧集（如 光阴之外.S01E31.mp4）；有 SxxExx/第x集 等线索时优先 tv
-            resourceInfo.type = (sortedFiles.length > 1 || hasSeasonEpisodeHint) ? 'tv' : 'movie';
+            }
+            let s00Max = 0;
+            for (const ep of resourceInfo.episode) {
+                if (ep.season === '00' || ep.season === 0) {
+                    const num = parseInt(ep.episode, 10);
+                    if (Number.isFinite(num) && num > s00Max) s00Max = num;
+                }
+            }
+            for (const ep of resourceInfo.episode) {
+                const fileName = fileById.get(String(ep.id)) || '';
+                if (fileName && isSpecialEpisodeName(fileName)) {
+                    if (ep.season !== '00' && ep.season !== 0) {
+                        ep.season = '00';
+                        ep.episode = pad2(++s00Max);
+                    }
+                }
+            }
+            // 季号覆盖：目录名/任务名解析出明确季号（如"第二季"→2）时，
+            // AI 可能仍返回默认 "01"——用 titleMeta.season 覆盖非特别篇的 season。
+            if (titleMeta.season != null && titleMeta.season > 0) {
+                const metaSeason = pad2(titleMeta.season);
+                for (const ep of resourceInfo.episode) {
+                    if (ep.season !== '00' && ep.season !== 0) {
+                        ep.season = metaSeason;
+                    }
+                }
+            }
+        }
+
+        // 统一注入源文件名标题（无论 AI 还是确定性分支），供 TMDB 搜索主候选
+        if (fileSearchTitle && !resourceInfo.searchTitle) {
+            resourceInfo = { ...resourceInfo, searchTitle: fileSearchTitle, searchYear: fileSearchYear || undefined };
         }
 
         // TMDB 锚定
         let resolvedTmdb = tmdbInfo || this.parseTaskTmdbContent(task?.tmdbContent);
-        if (!resolvedTmdb && this.tmdbService && (task?.tmdbId || resourceInfo.name)) {
+        // 电影合集不是单一 TMDB 实体：除非任务已显式绑定 tmdbId，否则跳过搜索锚定，
+        // 避免 searchMovie 碰巧命中其中某一部而把合集文件夹名改成那一部的标题。
+        const skipTmdbSearch = !!resourceInfo.isMovieCollection && !task?.tmdbId;
+        if (!resolvedTmdb && !skipTmdbSearch && this.tmdbService && (task?.tmdbId || resourceInfo.name)) {
             try {
                 resolvedTmdb = await this._resolveTmdb(task, resourceInfo);
             } catch (error) {
@@ -328,6 +431,10 @@ class MediaLibraryLayoutService {
 
         const libraryInfo = this._composeLibraryInfo(task, resourceInfo, resolvedTmdb);
         libraryInfo.locked = true;
+        // 保留目录名/任务名解析出的季号，序列化后供 buildRelativeDir fallback 使用
+        if (titleMeta.season != null && titleMeta.season > 0) {
+            libraryInfo.defaultSeason = pad2(titleMeta.season);
+        }
         libraryInfo.resourceInfo = {
             name: resourceInfo.name,
             year: resourceInfo.year,
@@ -335,7 +442,133 @@ class MediaLibraryLayoutService {
             season: resourceInfo.season,
             episode: resourceInfo.episode
         };
+
+        // 电影合集：逐文件匹配 TMDB，写入 files 数组（供刮削 + UI 使用）。
+        // 合集不锚定单一实体（skipTmdbSearch），但每个文件独立 searchMovie。
+        if (resourceInfo.isMovieCollection && Array.isArray(resourceInfo.episode)) {
+            const collectionFiles = await this._resolveCollectionFilesTmdb(resourceInfo.episode);
+            libraryInfo.files = collectionFiles.map((entry) => ({
+                ...entry,
+                organizedFileName: this.buildFileName(
+                    { name: `${entry.name || 'file'}${entry.extension || ''}` },
+                    entry,
+                    resourceInfo,
+                    libraryInfo
+                )
+            }));
+        }
         return libraryInfo;
+    }
+
+    /**
+     * 电影合集逐文件 TMDB 匹配：对每个文件的独立标题/年份调 searchMovie，
+     * 返回带 tmdbId/tmdbTitle/posterPath 的 files 数组。搜索失败的文件 tmdbId 为空。
+     * 复用 TMDBService 的 DB 缓存（details 7天 TTL），逐文件调用无额外架构成本。
+     */
+    async _resolveCollectionFilesTmdb(episodes = []) {
+        if (!this.tmdbService) {
+            return episodes.map((ep) => ({ ...ep, tmdbId: '', tmdbTitle: '', posterPath: '' }));
+        }
+        // 清洗标题里的集号噪声（"剧场版01："、"Movie10" 等），TMDB 搜索对此敏感
+        const cleanSearchTitle = (raw) => String(raw || '')
+            .replace(/剧场版\s*\d+\s*[:：]?/g, ' ')
+            .replace(/\bmovie\s*\d+\b/gi, ' ')
+            .replace(/第\s*\d+\s*部/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        const results = [];
+        for (const ep of episodes) {
+            const title = ep.name || '';
+            const year = ep.year || '';
+            let tmdbId = '', tmdbTitle = '', posterPath = '';
+            if (title) {
+                // 第一次：用清洗后的完整标题搜索
+                const candidates = [cleanSearchTitle(title)];
+                // 兜底：截断到冒号前的主标题（如"名侦探柯南：黑铁的鱼影"→ 都试）
+                const colonPart = title.split(/[:：]/).map((s) => cleanSearchTitle(s)).filter(Boolean);
+                candidates.push(...colonPart);
+                for (const q of [...new Set(candidates)]) {
+                    try {
+                        const detail = await this.tmdbService.searchMovie(q, year);
+                        if (detail?.id) {
+                            tmdbId = String(detail.id);
+                            tmdbTitle = detail.title || '';
+                            posterPath = detail.posterPath || '';
+                            break;
+                        }
+                    } catch (error) {
+                        logTaskEvent(`[Layout] 合集文件 TMDB 匹配失败「${q}」: ${error.message}`);
+                    }
+                }
+            }
+            results.push({ ...ep, tmdbId, tmdbTitle, posterPath });
+        }
+        const matched = results.filter((r) => r.tmdbId).length;
+        logTaskEvent(`[Layout] 合集逐文件 TMDB 匹配完成: ${matched}/${results.length}`);
+        return results;
+    }
+
+    /**
+     *确定性分类：无 AI 时从标题 + 文件列表推断 movie/tv 并补季集。
+     * 规则：
+     * - 多文件电影合集（标题含剧场版/电影/Movie，或"合集"+文件级证据）→ movie，
+     *   每个文件用自己解析出的独立标题/年份，供 Emby 刮削为独立电影条目；
+     * - 有 SxxExx/第x季 等季集线索 → tv；
+     * - 其余多文件 → tv（沿用原启发式）；单文件无线索 → movie。
+     */
+    _buildDeterministicResourceInfo(resourceInfo, resourceName, sortedFiles, collection = null) {
+        const parsedResource = parseMediaTitle(resourceName || '');
+        let hasSeasonEpisodeHint = parsedResource.season != null || parsedResource.episode != null;
+        const collectionInfo = collection || detectMovieCollection(resourceName, sortedFiles);
+        const isMovieCollection = collectionInfo.isMovieCollection;
+
+        // 预扫：原生 S00 文件（如 Show.S00E01.mkv）的最大集号，特别篇文件从后面接着编，避免撞号
+        let maxS00Episode = 0;
+        for (const f of sortedFiles) {
+            const p = parseMediaTitle(f.name || f.restoreName || '');
+            if (p.season === 0 && p.episode != null && p.episode > maxS00Episode) {
+                maxS00Episode = p.episode;
+            }
+        }
+        // 默认季号：优先用 resourceInfo.season（来自 resolveTitleMeta 的目录名/任务名解析，
+        // 如"第二季"→ season=2），否则回退 '01'
+        const defaultSeason = resourceInfo.season != null ? pad2(resourceInfo.season) : '01';
+        let specialCounter = maxS00Episode;
+        const episode = sortedFiles.map((file, index) => {
+            const fileName = file.name || file.restoreName || '';
+            const parsed = parseMediaTitle(fileName);
+            if (parsed.season != null || parsed.episode != null) {
+                hasSeasonEpisodeHint = true;
+            }
+            // 特别篇检测 → Season 00（Emby Specials），不占正片集号：
+            // - NCOP/NCED：无字幕片头片尾。不要求尾部词边界（[NCED03] 里 D 和 0 之间无 \b），
+            //   也不检查 parsed.episode（anitomy 可能把 NCED03 的 03 解析成集号）。
+            // - SP：特别篇（如 [SP01]），anitomy 会把 01 解析成正片集号导致撞号。
+            // - Non-Credit：无字幕版（如 [EP23 C-Part Non-Credit Ver.]），本质也是 NCED/NCOP。
+            const isSpecial = isSpecialEpisodeName(fileName);
+            if (isSpecial) specialCounter++;
+            const perFile = isMovieCollection ? collectionInfo.perFileNames.get(fileName) : null;
+            return {
+                id: String(file.id || file.entryKey || index),
+                // 电影合集：每个文件用自己的独立标题/年份；否则沿用合集标题
+                name: perFile?.title || resourceInfo.name,
+                year: perFile?.year != null ? perFile.year : resourceInfo.year,
+                season: isSpecial ? '00' : (parsed.season != null ? pad2(parsed.season) : defaultSeason),
+                episode: isSpecial
+                    ? pad2(specialCounter)
+                    : (parsed.episode != null
+                        ? (parsed.episode >= 100 ? String(parsed.episode) : pad2(parsed.episode))
+                        : pad2(index + 1)),
+                extension: path.extname(fileName) || ''
+            };
+        });
+
+        // 电影合集优先判 movie；否则单文件也可能是剧集（如 光阴之外.S01E31.mp4），有季集线索时优先 tv
+        const type = isMovieCollection
+            ? 'movie'
+            : ((sortedFiles.length > 1 || hasSeasonEpisodeHint) ? 'tv' : 'movie');
+
+        return { ...resourceInfo, type, episode, isMovieCollection };
     }
 
     _composeLibraryInfo(task, resourceInfo, tmdbInfo) {
@@ -384,13 +617,33 @@ class MediaLibraryLayoutService {
                 : await this.tmdbService.getTVDetails(task.tmdbId);
             if (detail?.id) return detail;
         }
-        const title = sanitizeTitle(resourceInfo?.name || task?.resourceName || '');
-        const year = resourceInfo?.year || '';
-        if (!title) return null;
-        if (preferredType === 'movie') {
-            return await this.tmdbService.searchMovie(title, year);
+        // 多候选搜索：文件名标题（英文规范命名）优先，目录名/任务名（中文标题）兜底。
+        // 如"浪浪山小妖怪"任务名本身就是精确中文标题，文件名可能是乱码编码名，此时回退命中。
+        // 搜索标题清洗：去掉 "Movie 1/2/3" 编号（TMDB 标题不含编号）
+        const cleanForSearch = (t) => sanitizeTitle(t).replace(/\bmovie\s*\d+\b/gi, '').replace(/\s+/g, ' ').trim();
+        const candidates = [];
+        if (resourceInfo?.searchTitle) {
+            candidates.push({ title: cleanForSearch(resourceInfo.searchTitle), year: resourceInfo.searchYear || resourceInfo.year || '' });
         }
-        return await this.tmdbService.searchTV(title, year, task?.currentEpisodes || 0);
+        const dirTitle = cleanForSearch(resourceInfo?.name || task?.resourceName || '');
+        if (dirTitle && dirTitle !== candidates[0]?.title) {
+            candidates.push({ title: dirTitle, year: resourceInfo?.year || '' });
+        }
+        if (!candidates.length) return null;
+        for (const c of candidates) {
+            const result = preferredType === 'movie'
+                ? await this.tmdbService.searchMovie(c.title, c.year)
+                : await this.tmdbService.searchTV(c.title, c.year, task?.currentEpisodes || 0);
+            if (result?.id) return result;
+            // 带年份未命中时去掉年份重试（合集子目录的年份常来自父级标题，与单部实际上映年不符）
+            if (c.year) {
+                const retry = preferredType === 'movie'
+                    ? await this.tmdbService.searchMovie(c.title, '')
+                    : await this.tmdbService.searchTV(c.title, '', task?.currentEpisodes || 0);
+                if (retry?.id) return retry;
+            }
+        }
+        return null;
     }
 
     async _analyzeWithCache(resourcePath, files) {
@@ -443,15 +696,21 @@ class MediaLibraryLayoutService {
             const aiFile = episodeMap.get(key) || null;
             // 若无 AI episode，用确定性解析补一份
             const effectiveAi = aiFile || (() => {
-                const parsed = parseMediaTitle(file.name || file.restoreName || file.originalFileName || '');
+                const sourceName = file.name || file.restoreName || file.originalFileName || '';
+                const parsed = parseMediaTitle(sourceName);
+                // 电影（非剧集）：每个文件用自己解析出的独立标题/年份，使电影合集的各部能独立命名；
+                // 同名多版本（标准版/HDR）会碰撞，交由下方 _disambiguateCollidingNames 追加版本标识。
+                // 剧集仍用合集标题 + 季集号（保持原行为）。
+                const isMovie = !info.seasonBased;
                 return {
                     id: key,
-                    name: info.canonicalTitle,
-                    season: parsed.season != null ? pad2(parsed.season) : '01',
+                    name: isMovie && parsed.cleanTitle ? parsed.cleanTitle : info.canonicalTitle,
+                    year: isMovie && parsed.year != null ? parsed.year : info.year,
+                    season: parsed.season != null ? pad2(parsed.season) : (info.defaultSeason || '01'),
                     episode: parsed.episode != null
                         ? (parsed.episode >= 100 ? String(parsed.episode) : pad2(parsed.episode))
                         : pad2(index + 1),
-                    extension: path.extname(file.name || file.restoreName || '') || ''
+                    extension: path.extname(sourceName) || ''
                 };
             })();
             const relativeDir = this.buildRelativeDir(file, effectiveAi, info);
@@ -582,6 +841,9 @@ module.exports = {
     normalizeLocalStrmPrefix,
     joinLocalStrmPath,
     sanitizePathSegment,
+    sanitizeTitle,
+    extractYear,
     joinPosix,
-    pad2
+    pad2,
+    isSpecialEpisodeName
 };

--- a/src/services/organizer.js
+++ b/src/services/organizer.js
@@ -100,6 +100,14 @@ class OrganizerService {
                     videoType: tmdbType,
                     tmdbContent: JSON.stringify(tmdbDetails)
                 };
+                // 同步季集数到任务（自动路径之前漏了，导致前端显示不出集数，需手动重绑 TMDB 才行）
+                if (tmdbType === 'tv') {
+                    const seasonNumber = Number(task.manualSeason || task.tmdbSeasonNumber || 1) || 1;
+                    const seasonEpisodes = this._getSeasonEpisodeCount(tmdbDetails, seasonNumber);
+                    canonicalMetadata.tmdbSeasonNumber = seasonNumber;
+                    canonicalMetadata.tmdbSeasonEpisodes = seasonEpisodes || Number(tmdbDetails.totalEpisodes || 0);
+                    canonicalMetadata.totalEpisodes = seasonEpisodes || Number(tmdbDetails.totalEpisodes || task.totalEpisodes || 0);
+                }
             }
         }
         Object.assign(task, canonicalMetadata);
@@ -757,6 +765,14 @@ class OrganizerService {
     _extractYear(value = '') {
         const matched = String(value || '').match(/(19|20)\d{2}/);
         return matched ? matched[0] : '';
+    }
+
+    _getSeasonEpisodeCount(detail, seasonNumber) {
+        if (!seasonNumber || !Array.isArray(detail?.seasons)) {
+            return 0;
+        }
+        const seasonInfo = detail.seasons.find(season => Number(season.season_number) === Number(seasonNumber));
+        return Number(seasonInfo?.episode_count || 0);
     }
 
     _sanitizeTitle(title = '') {

--- a/src/services/ptRename.js
+++ b/src/services/ptRename.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const { safeFileName } = require('./ptUtils');
 const ConfigService = require('./ConfigService');
+const { renderFileName } = require('../utils/templateRenderer');
+const { parseMediaTitle } = require('../utils/mediaTitleParser');
 
 // 默认集数提取正则（参考 ani-rss）
 const DEFAULT_EPISODE_REGEX = '(第\\d+[话話集]|EP?\\d+(\\.5)?| - \\d+(\\.5)?|\\[\\d+(\\.5)?\\]|【\\d+(\\.5)?】)';
@@ -41,6 +43,12 @@ class PtRenameService {
     extractSeason(title, customRegex = '', defaultSeason = 1) {
         if (!title) return defaultSeason;
 
+        // 无自定义正则时，优先走统一解析器（含 anitomy 动漫分流）
+        if (!customRegex) {
+            const parsed = parseMediaTitle(title);
+            if (parsed.season != null && parsed.season > 0) return parsed.season;
+        }
+
         try {
             const regexStr = customRegex || DEFAULT_SEASON_REGEX;
             const regex = new RegExp(regexStr, 'i');
@@ -74,6 +82,16 @@ class PtRenameService {
      */
     extractEpisode(title, customRegex = '') {
         if (!title) return null;
+
+        // 无自定义正则且无半集(.5)时，优先走统一解析器（含 anitomy 动漫分流）。
+        // 半集(.5)是 PT 专用形态，parseMediaTitle 不支持，保留正则回退处理。
+        if (!customRegex && !/\.5\b/.test(title)) {
+            const parsed = parseMediaTitle(title);
+            if (parsed.episode != null) {
+                const episode = parsed.episode;
+                return { episode, episodeStr: episode < 100 ? String(episode).padStart(2, '0') : String(episode) };
+            }
+        }
 
         try {
             const regexStr = customRegex || DEFAULT_EPISODE_REGEX;
@@ -210,8 +228,8 @@ class PtRenameService {
 
         // 文件名模板：与自动追剧 _processRename 一致
         const template = isMovie
-            ? (ConfigService.getConfigValue('openai.rename.movieTemplate') || '{name} ({year}){ext}')
-            : (ConfigService.getConfigValue('openai.rename.template') || '{name} - {se}{ext}');
+            ? (ConfigService.getConfigValue('openai.rename.movieTemplate') || '{{name}}{% if year %} ({{year}}){% endif %}{{ext}}')
+            : (ConfigService.getConfigValue('openai.rename.template') || '{{name}} - {{se}}{{ext}}');
 
         // 标题与年份
         // 目录和文件必须使用同一个标准标题，避免 TMDB 中文目录下混入 AI 提取的英文文件名。
@@ -241,24 +259,20 @@ class PtRenameService {
         const originalExt = path.extname(originalName);
         const ext = (aiEpisode && aiEpisode.extension) || originalExt || '';
 
-        // 占位符替换（与 task._generateFileName 一致）
-        const replaceMap = {
-            '{name}': title,
-            '{year}': year ? String(year) : '',
-            '{s}': seasonStr,
-            '{e}': episodeStr || '01',
-            '{sn}': seasonNum || 1,
-            '{en}': episodeNum || 1,
-            '{ext}': ext,
-            '{se}': `S${seasonStr}E${episodeStr || '01'}`
+        // 模板渲染（与 task._generateFileName / buildFileName 统一走 renderFileName）
+        const vars = {
+            name: title,
+            year: year ? String(year) : '',
+            s: seasonStr,
+            e: episodeStr || '01',
+            sn: seasonNum || 1,
+            en: episodeNum || 1,
+            ext: ext,
+            se: `S${seasonStr}E${episodeStr || '01'}`
         };
 
-        let baseName = template;
-        for (const [key, value] of Object.entries(replaceMap)) {
-            const escaped = key.replace(/[{}]/g, c => '\\' + c);
-            baseName = baseName.replace(new RegExp(escaped, 'g'), String(value));
-        }
-        // 模板里的 {ext} 已经把原始扩展拼上了，去掉以便统一换成 .strm
+        let baseName = renderFileName(template, vars);
+        // 模板里的 {{ext}} 已经把原始扩展拼上了，去掉以便统一换成 .strm
         if (ext && baseName.endsWith(ext)) {
             baseName = baseName.slice(0, -ext.length);
         }

--- a/src/services/strm.js
+++ b/src/services/strm.js
@@ -84,15 +84,30 @@ class StrmService {
             const expectedStrmPaths = new Set(
                 mediaFiles.map(file => this._buildRelativeStrmPath(file.relativeDir || '', file.name))
             );
+            // 本次文件覆盖的季目录集合——compare 清理和 overwrite 清除都限制在这个范围内
+            const coveredDirs = new Set(
+                mediaFiles.map(file => this._normalizeRelativePath(file.relativeDir || ''))
+            );
             if (compare) {
                 const strmFiles = await this._listStrmFilesRecursive(this._normalizeBaseRelativePath(taskRoot));
                 for (const file of strmFiles) {
+                    const dirName = path.dirname(file.relativePath);
+                    const normalizedDir = dirName === '.' ? '' : this._normalizeRelativePath(dirName);
+                    if (!coveredDirs.has(normalizedDir)) {
+                        continue;
+                    }
                     if (!expectedStrmPaths.has(file.relativePath)) {
                         await this.delete(file.path);
                     }
                 }
             }
-            overwrite && await this._deleteDirAllStrm(targetDir)
+            if (overwrite) {
+                // 只清除本次文件覆盖的季目录，避免误删同系列其他季的 STRM
+                for (const relDir of coveredDirs) {
+                    const dirPath = relDir ? path.join(targetDir, relDir) : targetDir;
+                    await this._deleteDirAllStrm(dirPath);
+                }
+            }
             await this._ensureDirectoryExists(targetDir);
             for (const file of files) {
                 // 检查文件是否是媒体文件
@@ -283,12 +298,13 @@ class StrmService {
             })
         );
 
+        // 本次文件覆盖的季目录集合——compare 清理和 overwrite 清除都限制在这个范围内，
+        // 避免同 targetRoot 下的兄弟目录(例如多季任务 Season 01 / Season 02)被误删
+        const coveredDirs = new Set(
+            mediaFiles.map(file => this._normalizeRelativePath(file.relativeDir || ''))
+        );
+
         if (compare) {
-            // 收窄 compare 范围: 仅在本次 files 实际涉及的子目录内做清理,
-            // 避免同 targetRoot 下的兄弟目录(例如多季任务 Season 01 / Season 02)被误删
-            const coveredDirs = new Set(
-                mediaFiles.map(file => this._normalizeRelativePath(file.relativeDir || ''))
-            );
             const strmFiles = await this._listStrmFilesRecursive(normalizedTargetRoot);
             for (const file of strmFiles) {
                 const dirName = path.dirname(file.relativePath);
@@ -302,7 +318,13 @@ class StrmService {
             }
         }
 
-        overwrite && await this._deleteDirAllStrm(targetDir);
+        if (overwrite) {
+            // 只清除本次文件覆盖的季目录，避免误删同系列其他季的 STRM
+            for (const relDir of coveredDirs) {
+                const dirPath = relDir ? path.join(targetDir, relDir) : targetDir;
+                await this._deleteDirAllStrm(dirPath);
+            }
+        }
         await this._ensureDirectoryExists(targetDir);
 
         for (const file of files) {

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -21,8 +21,9 @@ const { CasService } = require('./casService');
 const { CasArchiveService } = require('./casArchiveService');
 const { AppDataSource } = require('../database');
 const { TaskProcessedFile } = require('../entities');
-const { parseMediaTitle } = require('../utils/mediaTitleParser');
-const { MediaLibraryLayoutService, joinLocalStrmPath } = require('./mediaLibraryLayout');
+const { parseMediaTitle, detectMovieCollection, resolveTitleMeta } = require('../utils/mediaTitleParser');
+const { renderFileName } = require('../utils/templateRenderer');
+const { MediaLibraryLayoutService, joinLocalStrmPath, sanitizeTitle, extractYear } = require('./mediaLibraryLayout');
 
 function buildTaskTargetRelativePath(task = {}, mediaFile = {}, layout = null) {
     const mediaPath = String(mediaFile.relativePath || mediaFile.name || '')
@@ -51,6 +52,7 @@ class TaskService {
             ? AppDataSource.getRepository(TaskProcessedFile)
             : null);
         this.activeTaskExecutions = new Map();
+        this.initialTaskExecutions = new WeakMap();
         this.activeBatchExecution = null;
         this.activeStrmJobs = new Map(); // key -> Promise 防重复生成/重建
         this.autoSeriesService = null;
@@ -146,6 +148,16 @@ class TaskService {
             return '未知';
         }
         return task.shareFolderName ? `${task.resourceName}/${task.shareFolderName}` : (task.resourceName || `任务${task.id || ''}`);
+    }
+
+    async waitForInitialTaskExecution(task) {
+        const initialExecution = this.initialTaskExecutions?.get(task);
+        if (initialExecution) {
+            return await initialExecution;
+        }
+        const taskExecutionKey = this._getTaskExecutionKey(task);
+        const activeExecution = taskExecutionKey ? this.activeTaskExecutions.get(taskExecutionKey) : null;
+        return activeExecution ? await activeExecution : '';
     }
 
     _isAiAdvancedMode() {
@@ -748,8 +760,18 @@ class TaskService {
         }
         if (taskDto.enableCron) {
             for(const task of tasks) {
-                SchedulerService.saveTaskJob(task, this)   
+                SchedulerService.saveTaskJob(task, this)
             }
+        }
+        // 创建后立即执行一次（异步，不阻塞 API 响应）
+        for (const task of tasks) {
+            const initialExecution = this.processTask(task);
+            this.initialTaskExecutions.set(task, initialExecution);
+            initialExecution.then((result) => {
+                if (result) this.messageUtil.sendMessage(result, { level: 'success' });
+            }).catch((error) => {
+                logTaskEvent(`任务[${task.resourceName || ''}]创建后首次执行失败: ${error.message}`, 'error', 'transfer');
+            });
         }
         await logTaskEvent(`任务创建完成: created=${tasks.length}, resource=${shareInfo.fileName || taskDto.taskName || ''}`, 'info', 'task');
         return tasks;
@@ -1226,6 +1248,31 @@ class TaskService {
         return fileList;
     }
 
+    /**
+     * 递归收集分享目录下的所有文件（含子目录，如 S01/Season 01 等）。
+     * 解决套娃目录问题：分享根目录只有 NCOP/NCED，正片在 S01 子目录里。
+     */
+    async _collectShareFilesRecursive(cloud189, task, shareDirResult, relativeDir = '') {
+        if (!shareDirResult?.fileListAO) return [];
+        const currentRelativeDir = relativeDir ? relativeDir.replace(/^\/+|\/+$/g, '') : '';
+        const fileList = (shareDirResult.fileListAO.fileList || []).map(file => ({
+            ...file,
+            relativeDir: currentRelativeDir,
+            relativePath: currentRelativeDir ? path.join(currentRelativeDir, file.name) : file.name
+        }));
+        const folderList = (shareDirResult.fileListAO.folderList || [])
+            .filter(folder => !CasArchiveService.isReservedDirectory(folder.name));
+        const childFileGroups = await this._mapWithConcurrency(folderList, 4, async (folder) => {
+            const folderName = folder.name || folder.fileName || '';
+            const folderId = folder.id || folder.fileId;
+            const nextRelativeDir = currentRelativeDir ? path.join(currentRelativeDir, folderName) : folderName;
+            const subResult = await cloud189.listShareDir(task.shareId, folderId, task.shareMode, task.accessCode, true);
+            return await this._collectShareFilesRecursive(cloud189, task, subResult, nextRelativeDir);
+        });
+        childFileGroups.forEach(childFiles => fileList.push(...childFiles));
+        return fileList;
+    }
+
     async _mapWithConcurrency(items, limit, worker) {
         if (!items.length) {
             return [];
@@ -1612,8 +1659,8 @@ class TaskService {
         }
 
         if (this.activeTaskExecutions.has(taskExecutionKey)) {
-            logTaskEvent(`任务[${this._getTaskDisplayName(task)}]已在执行中，忽略重复触发`, 'warn', 'transfer');
-            return '';
+            logTaskEvent(`任务[${this._getTaskDisplayName(task)}]已在执行中，复用当前执行结果`, 'warn', 'transfer');
+            return await this.activeTaskExecutions.get(taskExecutionKey);
         }
 
         const executionPromise = this._processTaskInternal(task, options);
@@ -1670,7 +1717,7 @@ class TaskService {
                 logTaskEvent("获取文件列表失败: " + JSON.stringify(shareDir), 'error', 'transfer');
                 throw new Error('获取文件列表失败');
             }
-            let shareFiles = [...shareDir.fileListAO.fileList];
+            let shareFiles = await this._collectShareFilesRecursive(cloud189, task, shareDir);
             const enableOnlySaveMedia = this._shouldOnlySaveMedia(task);
             // mediaSuffixs转为小写
             const mediaSuffixs = ConfigService.getConfigValue('task.mediaSuffix').split(';').map(suffix => suffix.toLowerCase())
@@ -2241,74 +2288,48 @@ class TaskService {
     // 根据AI分析结果生成新文件名
     _generateFileName(file, aiFile, resourceInfo, template) {
         if (!aiFile) return file.name;
-        
-        // 构建文件名替换映射
-        const replaceMap = {
-            '{name}': aiFile.name || resourceInfo.name,
-            '{year}': resourceInfo.year || '',
-            '{s}': aiFile.season?.padStart(2, '0') || '01',
-            '{e}': aiFile.episode?.padStart(2, '0') || '01',
-            '{sn}': parseInt(aiFile.season) || '1',                    // 不补零的季数
-            '{en}': parseInt(aiFile.episode) || '1',                   // 不补零的集数
-            '{ext}': aiFile.extension || path.extname(file.name),
-            '{se}': `S${aiFile.season?.padStart(2, '0') || '01'}E${aiFile.episode?.padStart(2, '0') || '01'}`
-        };
 
-        // 替换模板中的占位符
-        let newName = template;
-        for (const [key, value] of Object.entries(replaceMap)) {
-            newName = newName.replace(new RegExp(key, 'g'), value);
-        }
+        const season = aiFile.season?.padStart(2, '0') || '01';
+        const episode = aiFile.episode?.padStart(2, '0') || '01';
+        const vars = {
+            name: aiFile.name || resourceInfo.name,
+            // 电影合集场景每个文件带独立年份（aiFile.year），优先于合集级年份
+            year: aiFile.year || resourceInfo.year || '',
+            s: season,
+            e: episode,
+            sn: String(parseInt(aiFile.season) || 1),   // 不补零的季数
+            en: String(parseInt(aiFile.episode) || 1),  // 不补零的集数
+            ext: aiFile.extension || path.extname(file.name),
+            se: `S${season}E${episode}`
+        };
+        const newName = renderFileName(template, vars);
         // 清理文件名中的非法字符
         return this._sanitizeFileName(newName);
     }
 
     _buildLocalRenameResourceInfo(task, files) {
+        // 委托给布局服务的确定性构造器，消除重复逻辑（标题层级补全 +合集判定 + 逐文件季集）
         const sortedFiles = [...files].sort((left, right) =>
             String(left.name || '').localeCompare(String(right.name || ''), 'zh-CN', { numeric: true, sensitivity: 'base' })
         );
-        const title = this._sanitizeMediaTitle(task.resourceName || '');
-        const year = this._extractYear(task.resourceName || '');
-        const resourceParsed = parseMediaTitle(task.resourceName || '');
-        let hasSeasonEpisodeHint = resourceParsed.season != null || resourceParsed.episode != null;
-        const parsedEpisodes = sortedFiles.map((file, index) => {
-            const parsed = parseMediaTitle(file.name || '');
-            if (parsed.season != null || parsed.episode != null) {
-                hasSeasonEpisodeHint = true;
-            }
-            const season = parsed.season != null ? String(parsed.season).padStart(2, '0') : '01';
-            const episode = parsed.episode != null
-                ? (parsed.episode >= 100 ? String(parsed.episode) : String(parsed.episode).padStart(2, '0'))
-                : String(index + 1).padStart(2, '0');
-            return {
-                id: String(file.id),
-                name: title,
-                season,
-                episode,
-                extension: path.extname(file.name) || ''
-            };
-        });
-        return {
-            name: title,
-            year,
-            // 单文件也可能是剧集（文件名带 SxxExx）；有季集线索时优先 tv
-            type: (sortedFiles.length > 1 || hasSeasonEpisodeHint) ? 'tv' : 'movie',
-            season: parsedEpisodes[0]?.season || '01',
-            episode: parsedEpisodes
+        const titleMeta = resolveTitleMeta(
+            { resourceName: task.resourceName || '', shareFolderName: task.shareFolderName || '' },
+            sortedFiles
+        );
+        const resourceInfo = {
+            name: sanitizeTitle(titleMeta.title || task.resourceName || '未命名') || '未命名',
+            year: titleMeta.year != null ? titleMeta.year : (extractYear(task.resourceName) || ''),
+            type: 'tv',
+            episode: []
         };
-    }
-
-    _sanitizeMediaTitle(value = '') {
-        return String(value || '')
-            .replace(/\(根\)$/g, '')
-            .replace(/[\[【(（](19|20)\d{2}[\]】)）]/g, '')
-            .replace(/\s+/g, ' ')
-            .trim();
-    }
-
-    _extractYear(value = '') {
-        const matched = String(value || '').match(/(19|20)\d{2}/);
-        return matched ? matched[0] : '';
+        const layoutService = new MediaLibraryLayoutService();
+        const result = layoutService._buildDeterministicResourceInfo(
+            resourceInfo,
+            titleMeta.title || task.resourceName || '',
+            sortedFiles
+        );
+        // 兼容旧返回结构：顶层补一个 season（取首个文件的季号）
+        return { ...result, season: result.episode?.[0]?.season || '01' };
     }
 
     buildOrganizerDirectoryName(aiFile, resourceInfo) {
@@ -2330,8 +2351,8 @@ class TaskService {
         // 处理aiFilename, 文件命名通过配置文件的占位符获取
         // 获取用户配置的文件名模板，如果没有配置则使用默认模板
         const template = resourceInfo.type === 'movie' 
-        ? ConfigService.getConfigValue('openai.rename.movieTemplate') || '{name} ({year}){ext}'  // 电影模板
-        : ConfigService.getConfigValue('openai.rename.template') || '{name} - {se}{ext}';  // 剧集模板
+        ? ConfigService.getConfigValue('openai.rename.movieTemplate') || '{{name}}{% if year %} ({{year}}){% endif %}{{ext}}'  // 电影模板
+        : ConfigService.getConfigValue('openai.rename.template') || '{{name}} - {{se}}{{ext}}';  // 剧集模板
         for (const file of files) {
             try {
                 const aiFile = newNames.find(f => f.id === file.id);
@@ -3272,8 +3293,8 @@ class TaskService {
     // ai命名处理
     async handleAiRename(files, resourceInfo) {
         const template = resourceInfo.type === 'movie' 
-        ? ConfigService.getConfigValue('openai.rename.movieTemplate') || '{name} ({year}){ext}'  // 电影模板
-        : ConfigService.getConfigValue('openai.rename.template') || '{name} - {se}{ext}';  // 剧集模板
+        ? ConfigService.getConfigValue('openai.rename.movieTemplate') || '{{name}}{% if year %} ({{year}}){% endif %}{{ext}}'  // 电影模板
+        : ConfigService.getConfigValue('openai.rename.template') || '{{name}} - {{se}}{{ext}}';  // 剧集模板
         const aiNames = Array.isArray(resourceInfo?.episode) ? resourceInfo.episode : [];
         const newFiles = [];
         for (const file of files) {
@@ -3391,7 +3412,8 @@ class TaskService {
         if (!shareDir?.fileListAO?.fileList) {
             throw new Error('获取分享目录失败');
         }
-        return await this._getLazyStrmFiles(task, [...shareDir.fileListAO.fileList]);
+        const shareFiles = await this._collectShareFilesRecursive(cloud189, task, shareDir);
+        return await this._getLazyStrmFiles(task, shareFiles);
     }
 
     /**
@@ -3420,9 +3442,9 @@ class TaskService {
         const existingNames = new Set(folderFiles.map(f => f.name));
         const existingMediaIndex = this._buildExistingMediaIndex(folderFiles, task);
 
-        // 2. 获取分享源文件，用于比对
+        // 2. 获取分享源文件，用于比对（递归收集含子目录）
         const shareDir = await cloud189.listShareDir(task.shareId, task.shareFolderId, task.shareMode, task.accessCode, task.isFolder);
-        const shareFiles = (shareDir?.fileListAO?.fileList || []).filter(f => !f.isFolder);
+        const shareFiles = (await this._collectShareFilesRecursive(cloud189, task, shareDir)).filter(f => !f.isFolder);
 
         // 3. 同步子记录 (Detail) - 该方法已包含对 .cas/restoreName 的多重匹配
         const repairedCount = await this._syncTaskDetailRecordsWithActualFiles(task);

--- a/src/services/taskEventHandler.js
+++ b/src/services/taskEventHandler.js
@@ -114,9 +114,24 @@ class TaskEventHandler {
                 const strmPath = strmService.getStrmPath(task);
                 if (strmPath) {
                     const scrapeService = new ScrapeService();
-                    logTaskEvent(`开始刮削tmdbId: ${task.tmdbId}的媒体信息, 路径: ${strmPath}`);
-                    const mediaDetails = await scrapeService.scrapeFromDirectory(strmPath, task.tmdbId);
-                    if (mediaDetails) {
+                    // 电影合集：从锁定布局读取逐文件 TMDB 数据，逐文件独立刮削
+                    let collectionFiles = null;
+                    try {
+                        const layout = task.libraryLayout ? JSON.parse(task.libraryLayout) : null;
+                        if (layout?.mediaType === 'movie' && Array.isArray(layout.files) && layout.files.length > 1) {
+                            collectionFiles = layout.files;
+                        }
+                    } catch (_) {}
+                    logTaskEvent(`开始刮削${collectionFiles ? '合集(' + collectionFiles.length + '部)' : ' tmdbId: ' + task.tmdbId}的媒体信息, 路径: ${strmPath}`);
+                    const mediaDetails = await scrapeService.scrapeFromDirectory(strmPath, task.tmdbId, collectionFiles);
+                    if (mediaDetails?.collection) {
+                        // 合集刮削：逐文件独立，不写任务级 tmdbId，推送汇总消息
+                        this.messageUtil.sendScrapeMessage({
+                            title: `✅ 合集刮削成功：${mediaDetails.scraped} 部`,
+                            description: `跳过 ${mediaDetails.skipped} 部（未匹配 TMDB）`,
+                            type: 'movie'
+                        }, { level: 'scrape' });
+                    } else if (mediaDetails) {
                         if (task.tmdbId != mediaDetails.tmdbId) {
                             await taskRepo.update(task.id, {
                                 tmdbId: mediaDetails.tmdbId,

--- a/src/services/telegramBot/handlers/tasks.js
+++ b/src/services/telegramBot/handlers/tasks.js
@@ -279,13 +279,10 @@ async function handleCreateTask(svc, chatId, data, messageId) {
         };
 
         const tasks = await svc.taskService.createTask(taskDto);
-        const taskIds = tasks.map(t => t.id);
-
         await edit(svc.bot, chatId, messageId, '✅ 任务创建成功，执行中...');
 
-        if (taskIds.length > 0) {
-            await svc.taskService.processAllTasks(true, taskIds);
-        }
+        // createTask 已启动首次执行；等待同一批 Promise，避免重复触发或提前报告完成。
+        await Promise.all(tasks.map(task => svc.taskService.waitForInitialTaskExecution(task)));
 
         await deleteMsg(svc.bot, chatId, messageId);
         await send(svc.bot, chatId, '✅ 任务执行完成');

--- a/src/utils/mediaTitleParser.js
+++ b/src/utils/mediaTitleParser.js
@@ -1,9 +1,13 @@
+const anitomy = require('anitomy-ng');
+
 const SEASON_EPISODE_PATTERNS = [
     /(?:^|[\s._-])S(\d{1,2})\s*E(\d{1,3})(?=[\s._-]|$)/i,
     /(?:^|[\s._-])(\d{1,2})x(\d{1,3})(?=[\s._-]|$)/i,
     /(?:^|[\s._-])S(\d{1,2})(?=[\s._-]|$)/i,
     /(?:^|[\s._-])Season\s*(\d{1,2})(?=[\s._-]|$)/i,
-    /(?:^|[\s._-])第\s*(\d{1,2})\s*季(?=[\s._-]|$)/i
+    /(?:^|[\s._-])第\s*(\d{1,2})\s*季(?=[\s._-]|$)/i,
+    // 动漫字幕组方括号集号：[08]、【08】（group1 空 → 仅集号，无季号）
+    /[\[【]()(\d{1,3})[\]】]/
 ];
 
 const CN_NUMBER_MAP = new Map([
@@ -68,11 +72,71 @@ function normalizeSpaces(text) {
     return text.replace(/[\s._]+/g, ' ').trim();
 }
 
+/**
+ * 启发式判断文件名是否为动漫风格（学 MoviePilot 的 is_anime）。
+ * 只有明确动漫命名才走 anitomy 专用解析器，标准点分命名走通用正则。
+ */
+function isAnimeStyle(name) {
+    const t = String(name || '');
+    // 方括号堆叠：[字幕组] 标题 [01][1080p]
+    if ((t.match(/\[[^\]]+\]/g) || []).length >= 2) return true;
+    // 【字幕组】标题【01】：要求至少一组是纯数字（集号），
+    // 排除资源标题里的【日漫电影】【211.78GB】等非动漫标记
+    const cjkGroups = t.match(/【[^】]+】/g) || [];
+    if (cjkGroups.length >= 2 && cjkGroups.some((g) => /^【\d{1,3}】$/.test(g))) return true;
+    // " - 01 " 集号分隔（动漫常见）
+    if (/\s-\s\d{1,3}\s/.test(t)) return true;
+    return false;
+}
+
+/**
+ * 用 anitomy 解析动漫文件名，返回与 parseMediaTitle 相同的结构。
+ * anitomy 原生支持 [字幕组]/[集号]/第x话/EP01/集数范围 等动漫专用形态。
+ */
+function parseAnimeTitle(name) {
+    let elements;
+    try {
+        elements = anitomy.parse(String(name || ''));
+    } catch (_) {
+        return null;
+    }
+    if (!Array.isArray(elements)) return null;
+    const get = (kind) => elements.filter((e) => e.kind === kind).map((e) => e.value);
+    const title = normalizeSpaces(get('title').join(' '));
+    const episodeRaw = get('episode'); // 集数范围时可能有多个，取第一个（起始集）
+    const episode = episodeRaw.length ? parseInt(episodeRaw[0], 10) : null;
+    const seasonRaw = get('season');
+    const season = seasonRaw.length ? parseInt(seasonRaw[0], 10) : null;
+    const yearRaw = get('year');
+    const year = yearRaw.length ? parseInt(yearRaw[0], 10) : null;
+    return {
+        rawName: name,
+        cleanTitle: title,
+        year: Number.isFinite(year) ? year : null,
+        season: Number.isFinite(season) ? season : null,
+        episode: Number.isFinite(episode) ? episode : null,
+        aliases: [],
+        removedTokens: []
+    };
+}
+
 function parseMediaTitle(source) {
+    // 动漫风格走 anitomy 专用解析器；解析失败（空标题）回退到通用正则
+    if (isAnimeStyle(source)) {
+        const animeResult = parseAnimeTitle(source);
+        if (animeResult && animeResult.cleanTitle) {
+            return animeResult;
+        }
+    }
+
     let text = source || '';
-    
+
     // 1. 先把所有点号、下划线转换为空格，方便后续匹配
     text = text.replace(/[._]/g, ' ');
+
+    // 1.5 去掉开头的字幕组/标签方括号（如 [MAI]、[Nekomoe kissaten]），
+    // 但保留纯数字方括号（如 [08]，那是集号）
+    text = text.replace(/^(?:\[[^\]\d][^\]]*\]\s*)+/i, '');
     const textForSeasonEpisode = text;
 
     // 2. 暴力截断：遇到常见的元数据起始符，直接砍掉后面所有内容
@@ -158,4 +222,104 @@ function parseMediaTitle(source) {
     };
 }
 
-module.exports = { parseMediaTitle };
+// 电影合集检测：多部独立电影打包成一个资源（如"名侦探柯南剧场版01-26合集"）。
+// 这类资源文件数 > 1，若按"多文件即剧集"的启发式会被误判为电视剧。
+// 标题强信号（剧场版/电影/Movie）直接判定；弱信号（合集/收藏版）需文件级证据配合。
+// 注意：模式用子串匹配而非 \b 边界——"Movie10" 这类粘连写法在 e/1 之间没有词边界。
+const MOVIE_TITLE_PATTERN = /剧场版|大电影|电影|影片|movie|film|theatrical/i;
+const COLLECTION_TITLE_PATTERN = /合集|收藏版|系列全|collection|complete|all[\s._-]?in[\s._-]?one/i;
+const MOVIE_FILE_PATTERN = /movie|剧场版|大电影/i;
+
+/**
+ * 判断一个多文件资源是否为"电影合集"，并给出每个文件独立解析出的标题/年份。
+ * @param {string} resourceName 资源/分享标题
+ * @param {Array<{name?:string, restoreName?:string}>} files 文件列表
+ * @returns {{isMovieCollection:boolean, perFileNames:Map<string,{title:string,year:number|null}>}}
+ */
+function detectMovieCollection(resourceName = '', files = []) {
+    const title = String(resourceName || '');
+    const titleParsed = parseMediaTitle(title);
+    const hasSeasonHintInTitle = titleParsed.season != null || titleParsed.episode != null;
+
+    const perFileNames = new Map();
+    let movieFileHits = 0;
+    let filesWithYear = 0;
+    let filesWithSeasonHint = 0;
+    const distinctYears = new Set();
+
+    for (const file of files) {
+        const name = file.name || file.restoreName || '';
+        const parsed = parseMediaTitle(name);
+        perFileNames.set(name, { title: parsed.cleanTitle, year: parsed.year });
+        if (MOVIE_FILE_PATTERN.test(name)) movieFileHits += 1;
+        if (parsed.season != null || parsed.episode != null) filesWithSeasonHint += 1;
+        if (parsed.year != null) {
+            filesWithYear += 1;
+            distinctYears.add(parsed.year);
+        }
+    }
+
+    const total = files.length;
+    // 过半文件带 SxxExx/第x季 等季集线索 → 是剧集而非电影合集（如"电影少女"这类含"电影"字样的剧集）
+    const filesLookEpisodic = total > 0 && filesWithSeasonHint / total >= 0.5;
+    // 文件级证据：过半文件带 Movie/剧场版 字样，或过半文件带各自不同的年份
+    const filesLookLikeMovies = total > 0 && (
+        movieFileHits / total >= 0.5 ||
+        (filesWithYear / total >= 0.5 && distinctYears.size >= Math.min(2, total))
+    );
+
+    let isMovieCollection = false;
+    if (total > 1 && !hasSeasonHintInTitle && !filesLookEpisodic) {
+        // 强信号（标题含剧场版/电影/Movie）也要求文件级佐证，防止"电影少女"这类
+        // 标题含"电影"但实为剧集的误判——文件须表现为多部独立电影（年份分散或含 Movie 字样）。
+        if (MOVIE_TITLE_PATTERN.test(title) && filesLookLikeMovies) {
+            isMovieCollection = true;
+        } else if (filesLookLikeMovies && (COLLECTION_TITLE_PATTERN.test(title) || movieFileHits / total >= 0.5)) {
+            // 标题仅说"合集"或无信号：需要文件级证据佐证
+            isMovieCollection = true;
+        }
+    }
+
+    return { isMovieCollection, perFileNames };
+}
+
+/**
+ * 层级补全：合并文件名、选中目录名、父级标题三个来源。
+ * - title：优先中文标题（目录名/父级名通常是中文，适合做文件夹名）；
+ *          无中文来源时回退到文件解析标题（如纯英文电影）。
+ * - year/season/episode：按 文件名 → 目录名 → 父级 优先级取第一个非空值（文件名最精确）。
+ * 返回统一的 { title, year, season, episode } 对象。
+ */
+function resolveTitleMeta(task = {}, files = []) {
+    const fileName = files[0]?.name || files[0]?.restoreName || '';
+    const dirName = task.shareFolderName || '';
+    const parentTitle = task.resourceName || '';
+
+    const fileParsed = fileName ? parseMediaTitle(fileName) : null;
+    const dirParsed = dirName ? parseMediaTitle(dirName) : null;
+    const parentParsed = parentTitle ? parseMediaTitle(parentTitle) : null;
+
+    // title：优先中文来源（目录名 → 父级名），回退文件标题
+    const hasCJK = (s) => /[一-鿿]/.test(s || '');
+    let title = '';
+    if (dirParsed?.cleanTitle && hasCJK(dirParsed.cleanTitle)) title = dirParsed.cleanTitle;
+    else if (parentParsed?.cleanTitle && hasCJK(parentParsed.cleanTitle)) title = parentParsed.cleanTitle;
+    else title = fileParsed?.cleanTitle || dirParsed?.cleanTitle || parentParsed?.cleanTitle || '';
+
+    // year/season/episode：文件名最精确，依次回退
+    const pick = (field) => {
+        for (const p of [fileParsed, dirParsed, parentParsed]) {
+            if (p && p[field] != null) return p[field];
+        }
+        return null;
+    };
+
+    return {
+        title,
+        year: pick('year'),
+        season: pick('season'),
+        episode: pick('episode')
+    };
+}
+
+module.exports = { parseMediaTitle, detectMovieCollection, resolveTitleMeta, isAnimeStyle };

--- a/src/utils/settingsValidation.js
+++ b/src/utils/settingsValidation.js
@@ -1,0 +1,15 @@
+const cron = require('node-cron');
+
+function validateLazyFileCleanupSettings(settings = {}) {
+    const taskSettings = settings.task || {};
+    const retentionHours = Number(taskSettings.lazyFileRetentionHours);
+    if (!Number.isFinite(retentionHours) || retentionHours < 1) {
+        return '懒转存文件保留时长不能小于 1 小时';
+    }
+    if (!cron.validate(taskSettings.lazyFileCleanupCron || '')) {
+        return '懒转存清理 Cron 表达式无效';
+    }
+    return null;
+}
+
+module.exports = { validateLazyFileCleanupSettings };

--- a/src/utils/templateRenderer.js
+++ b/src/utils/templateRenderer.js
@@ -1,0 +1,59 @@
+/**
+ * 统一命名模板渲染器（nunjucks / Jinja2 风格）。
+ * 支持条件渲染：{{name}}{% if year %} ({{year}}){% endif %}{{ext}}
+ * 兼容旧占位符格式：{name} ({year}){ext} → 自动迁移为 nunjucks 语法。
+ */
+const nunjucks = require('nunjucks');
+
+const env = new nunjucks.Environment(null, { autoescape: false, trimBlocks: true });
+
+// 旧占位符 → nunjucks 变量映射
+const LEGACY_MAP = {
+    '{name}': '{{name}}',
+    '{year}': '{{year}}',
+    '{s}': '{{s}}',
+    '{e}': '{{e}}',
+    '{sn}': '{{sn}}',
+    '{en}': '{{en}}',
+    '{ext}': '{{ext}}',
+    '{se}': '{{se}}'
+};
+
+/**
+ * 将旧占位符模板迁移为 nunjucks 语法。
+ * " ({year})" 整体迁移为条件渲染，年份为空时连括号和空格一起省掉。
+ */
+function migrateTemplate(tpl) {
+    let result = String(tpl || '');
+    // " ({year})" → 条件渲染（含括号和空格）
+    result = result.replace(/\s*\(\{year\}\)/g, '{% if year %} ({{year}}){% endif %}');
+    // 剩余的裸 {year}（不在括号里、也未被迁移）→ 普通变量
+    // 负向断言避免匹配已迁移的 {{year}}
+    result = result.replace(/(?<!\{)\{year\}/g, '{{year}}');
+    for (const [old, nw] of Object.entries(LEGACY_MAP)) {
+        if (old === '{year}') continue; // 已处理
+        result = result.split(old).join(nw);
+    }
+    return result;
+}
+
+/**
+ * 渲染文件名模板。
+ * @param {string} template - nunjucks 模板或旧占位符模板（自动检测迁移）
+ * @param {object} vars - { name, year, s, e, sn, en, ext, se }
+ * @returns {string} 渲染后的文件名
+ */
+function renderFileName(template, vars = {}) {
+    const raw = String(template || '');
+    // 已是 nunjucks 格式（含 {{ 或 {%）直接用；否则是旧占位符，先迁移
+    const isNunjucks = /\{\{|\{%/.test(raw);
+    const tpl = isNunjucks ? raw : migrateTemplate(raw);
+    try {
+        return env.renderString(tpl, vars).trim();
+    } catch (_) {
+        // 模板语法错误时回退到简单拼接
+        return [vars.name, vars.year ? `(${vars.year})` : '', vars.ext || ''].join(' ').trim();
+    }
+}
+
+module.exports = { renderFileName, migrateTemplate };

--- a/test/animeParser.test.js
+++ b/test/animeParser.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseMediaTitle, resolveTitleMeta, isAnimeStyle } = require('../src/utils/mediaTitleParser');
+
+test('isAnimeStyle: 方括号堆叠判定为动漫', () => {
+    assert.equal(isAnimeStyle('[MAI] Puella Magi Madoka Magica [08][Ma10p_2160p].mkv'), true);
+    assert.equal(isAnimeStyle('[Nekomoe kissaten][20 Seiki Denki Mokuroku][04][1080p].mp4'), true);
+    assert.equal(isAnimeStyle('【喵萌奶茶屋】★07月新番★[时光代理人][01][1080p].mp4'), true);
+});
+
+test('isAnimeStyle: 标准点分命名不是动漫', () => {
+    assert.equal(isAnimeStyle('Detective.Conan.Movie10.2006.BluRay.mkv'), false);
+    assert.equal(isAnimeStyle('光阴之外.S01E31.2025.2160p.WEB-DL.mkv'), false);
+    assert.equal(isAnimeStyle('Some.Movie.2024.1080p.mkv'), false);
+});
+
+test('isAnimeStyle: " - 01 " 集号分隔判定为动漫', () => {
+    assert.equal(isAnimeStyle('Frieren - Beyond Journeys End - 01 [1080p].mkv'), true);
+});
+
+test('parseMediaTitle: 动漫走 anitomy 解析出集号', () => {
+    const p = parseMediaTitle('[MAI] Puella Magi Madoka Magica [08][Ma10p_2160p][x265_flac_aac_ass].mkv');
+    assert.equal(p.episode, 8);
+    assert.ok(p.cleanTitle.includes('Puella Magi Madoka Magica'), `标题应含作品名: ${p.cleanTitle}`);
+    assert.ok(!p.cleanTitle.includes('MAI'), '标题不应含字幕组');
+});
+
+test('parseMediaTitle: 动漫中文标题 + 集号', () => {
+    const p = parseMediaTitle('【喵萌奶茶屋】★07月新番★[时光代理人][01][1080p][简日双语].mp4');
+    assert.equal(p.episode, 1);
+    assert.ok(p.cleanTitle.includes('时光代理人'), `标题应含作品名: ${p.cleanTitle}`);
+});
+
+test('parseMediaTitle: 非动漫 SxxExx 不受影响', () => {
+    const p = parseMediaTitle('光阴之外.S01E31.2025.2160p.WEB-DL.mkv');
+    assert.equal(p.season, 1);
+    assert.equal(p.episode, 31);
+    assert.equal(p.year, 2025);
+    assert.ok(p.cleanTitle.includes('光阴之外'), `标题: ${p.cleanTitle}`);
+});
+
+test('parseMediaTitle: 非动漫电影不受影响', () => {
+    const p = parseMediaTitle('Detective.Conan.Movie10.2006.BluRay.mkv');
+    assert.equal(p.year, 2006);
+    assert.equal(p.episode, null);
+});
+
+test('resolveTitleMeta: 中文标题优先 + 文件名补年份', () => {
+    const meta = resolveTitleMeta(
+        { resourceName: '魔法少女小圆 系列合集(2011-2015)', shareFolderName: '2.魔法少女小圆 剧场版 前篇 起始的物语 [Kamigami&MAI]' },
+        [{ name: '[MAI] Puella Magi Madoka Magica Movie 1 Beginnings (2012) [Ma10p_2160p].mkv' }]
+    );
+    // title 取中文目录名，year 取文件名的 2012（比父级 2011 精确）
+    assert.ok(meta.title.includes('魔法少女小圆'), `title: ${meta.title}`);
+    assert.equal(meta.year, 2012);
+});
+
+test('resolveTitleMeta: 纯英文资源回退文件标题', () => {
+    const meta = resolveTitleMeta(
+        { resourceName: 'Some.Movie.2024', shareFolderName: '' },
+        [{ name: 'Some.Movie.2024.1080p.BluRay.mkv' }]
+    );
+    assert.ok(meta.title.length > 0, '应有标题');
+    assert.equal(meta.year, 2024);
+});
+
+test('resolveTitleMeta: 动漫剧集文件名补集号', () => {
+    const meta = resolveTitleMeta(
+        { resourceName: '魔法少女小圆 (2011)', shareFolderName: '1.魔法少女小圆 [Kamigami&MAI]' },
+        [{ name: '[MAI] Puella Magi Madoka Magica [08][Ma10p_2160p].mkv' }]
+    );
+    assert.equal(meta.episode, 8);
+});

--- a/test/movieCollection.test.js
+++ b/test/movieCollection.test.js
@@ -1,0 +1,245 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { detectMovieCollection } = require('../src/utils/mediaTitleParser');
+const { MediaLibraryLayoutService } = require('../src/services/mediaLibraryLayout');
+
+// 柯南剧场版合集：标题含"剧场版/电影/合集"，文件是独立电影命名（MovieNN + 各自年份）
+const CONAN_TITLE = '【日漫电影】名侦探柯南剧场版01-26合集(1997-2023)1080P蓝光收藏版 国粤日三语音轨 内封简繁日字幕 TrueHD5.1【211.78GB】(根)';
+const CONAN_FILES = [
+    { id: '1', name: "Detective.Conan.Movie01.The.Time.Bombed.Skyscraper.1997.BluRay.1080p.x265-CHD.mkv" },
+    { id: '2', name: "Detective.Conan.Movie02.The.Fourteenth.Target.1998.BluRay.1080p.x265-CHD.mkv" },
+    { id: '3', name: "Detective.Conan.Movie10.The.Private.Eyes.Requiem.2006.BluRay.1080p.x265-CHD.mkv" },
+    { id: '4', name: "Detective.Conan.Movie26.Black.Iron.Submarine.2023.BluRay.1080p.x265-CHD.mkv" }
+];
+
+test('detectMovieCollection: 柯南剧场版合集判为电影合集', () => {
+    const result = detectMovieCollection(CONAN_TITLE, CONAN_FILES);
+    assert.equal(result.isMovieCollection, true);
+    // 每个文件解析出各自独立的年份
+    const years = CONAN_FILES.map((f) => result.perFileNames.get(f.name).year);
+    assert.deepEqual(years, [1997, 1998, 2006, 2023]);
+});
+
+test('detectMovieCollection: 普通剧集（多文件带 SxxExx）不是电影合集', () => {
+    const files = [
+        { id: '1', name: '光阴之外.S01E30.2025.2160p.WEB-DL.mkv' },
+        { id: '2', name: '光阴之外.S01E31.2025.2160p.WEB-DL.mkv' }
+    ];
+    const result = detectMovieCollection('光阴之外 全31集 4K', files);
+    assert.equal(result.isMovieCollection, false);
+});
+
+test('detectMovieCollection: 含"电影"字样的剧集被文件级季集证据否决', () => {
+    // "电影少女"是剧集，标题含"电影"，但文件带 SxxExx → 不能误判为电影合集
+    const files = [
+        { id: '1', name: '电影少女.S01E01.mkv' },
+        { id: '2', name: '电影少女.S01E02.mkv' }
+    ];
+    const result = detectMovieCollection('电影少女 2018 全12集', files);
+    assert.equal(result.isMovieCollection, false);
+});
+
+test('detectMovieCollection: 标题含"合集"但无电影信号、文件无年份 → 不判合集', () => {
+    const files = [
+        { id: '1', name: 'Some.Show.E01.mkv' },
+        { id: '2', name: 'Some.Show.E02.mkv' }
+    ];
+    // 标题有"合集"但文件既无 Movie 字样也无年份 → 证据不足
+    const result = detectMovieCollection('某资源合集', files);
+    assert.equal(result.isMovieCollection, false);
+});
+
+test('detectMovieCollection: 单文件永远不是合集', () => {
+    const result = detectMovieCollection(CONAN_TITLE, [CONAN_FILES[0]]);
+    assert.equal(result.isMovieCollection, false);
+});
+
+test('resolveLibraryInfo 确定性分支: 电影合集判 movie 且逐文件独立命名', async () => {
+    const service = new MediaLibraryLayoutService(); // 无 taskService/tmdbService → 走确定性分支
+    const libraryInfo = await service.resolveLibraryInfo({
+        resourceName: CONAN_TITLE,
+        files: CONAN_FILES,
+        task: null,
+        forceRefresh: true,
+        useAi: false
+    });
+
+    assert.equal(libraryInfo.mediaType, 'movie');
+    assert.equal(libraryInfo.seasonBased, false);
+    assert.equal(libraryInfo.categoryName, '电影');
+    // 每个 episode 条目带各自独立的年份
+    const yearById = new Map((libraryInfo.resourceInfo.episode || []).map((ep) => [ep.id, ep.year]));
+    assert.equal(yearById.get('1'), 1997);
+    assert.equal(yearById.get('4'), 2023);
+});
+
+test('resolveLibraryInfo 确定性分支: 普通多文件剧集仍判 tv', async () => {
+    const service = new MediaLibraryLayoutService();
+    const files = [
+        { id: '1', name: '金关.S01E14.2026.WEB-DL.mkv' },
+        { id: '2', name: '金关.S01E15.2026.WEB-DL.mkv' }
+    ];
+    const libraryInfo = await service.resolveLibraryInfo({
+        resourceName: '金关 (2026) 全30集',
+        files,
+        task: null,
+        forceRefresh: true,
+        useAi: false
+    });
+    assert.equal(libraryInfo.mediaType, 'tv');
+    assert.equal(libraryInfo.seasonBased, true);
+});
+
+test('buildFileName: movie 合集使用文件自己的年份', () => {
+    const service = new MediaLibraryLayoutService();
+    const libraryInfo = { mediaType: 'movie', categoryName: '电影', canonicalTitle: '名侦探柯南剧场版合集', year: '1997', resourceFolderName: '名侦探柯南剧场版合集 (1997)' };
+    const resourceInfo = { name: '名侦探柯南剧场版合集', year: '1997', type: 'movie' };
+    const aiFile = { name: 'Detective Conan Movie10', year: 2006, season: '01', episode: '03', extension: '.mkv' };
+    const fileName = service.buildFileName({ name: 'x.mkv' }, aiFile, resourceInfo, libraryInfo);
+    // 默认 movieTemplate: {name} ({year}){ext} → 用 aiFile.year=2006 而非合集 1997
+    assert.match(fileName, /2006/);
+    assert.doesNotMatch(fileName, /1997/);
+});
+
+test('applyLayoutToFiles: 锁定布局缺 episode 数据时电影仍逐文件独立命名', () => {
+    // 生产 bug 场景：懒任务第二次 resolveLibraryInfo 命中锁定布局，
+    // 序列化后的布局不含 resourceInfo/episode 数组 → episodeMap 为空。
+    // 电影兜底分支必须用文件自己的标题/年份，否则全部碰撞成"版本N"。
+    const service = new MediaLibraryLayoutService();
+    const lockedInfo = {
+        mediaType: 'movie', categoryName: '电影', seasonBased: false,
+        canonicalTitle: '名侦探柯南剧场版合集', year: '1997',
+        resourceFolderName: '名侦探柯南剧场版合集 (1997)', locked: true
+    };
+    const files = [
+        { id: '1', name: 'Detective.Conan.Movie01.The.Time-Bombed.Skyscraper.1997.BluRay.1080p.x265-CHD.mkv' },
+        { id: '2', name: 'Detective.Conan.Movie10.The.Private.Eyes.Requiem.2006.BluRay.1080p.x265-CHD.mkv' }
+    ];
+    const applied = service.applyLayoutToFiles({
+        localStrmPrefix: '', libraryInfo: lockedInfo, resourceInfo: null, files
+    });
+    const names = applied.files.map((f) => f.name);
+    assert.ok(names[0].includes('1997'), `第1个应含 1997: ${names[0]}`);
+    assert.ok(names[1].includes('2006'), `第2个应含 2006: ${names[1]}`);
+    assert.notEqual(names[0], names[1], '两个文件名不应相同（碰撞）');
+    // 电影无 Season 目录
+    assert.equal(applied.files[0].relativeDir, '');
+});
+
+test('AI 路径: 电影合集跳过任务级 TMDB 锚定，但逐文件匹配 TMDB', async () => {
+    // 生产 bug 场景：AI 判对 movie 后走 TMDB 锚定，searchMovie("名侦探柯南")
+    // 命中第一部剧场版（计时引爆摩天楼），把合集文件夹名改成那一部的标题。
+    // 修复后：合集跳过任务级锚定（_resolveTmdb），但逐文件 searchMovie 匹配各自的 TMDB 条目。
+    const searchedTitles = [];
+    const fakeTaskService = {
+        _analyzeResourceInfo: async () => ({
+            name: '名侦探柯南剧场版合集', year: 1997, type: 'movie', season: '01',
+            episode: CONAN_FILES.map((f, i) => ({
+                id: f.id, name: '名侦探柯南剧场版合集', season: '01',
+                episode: String(i + 1).padStart(2, '0'), extension: '.mkv'
+            }))
+        })
+    };
+    const fakeTmdbService = {
+        searchMovie: async (title) => {
+            searchedTitles.push(title);
+            return { id: 21422, title: '名侦探柯南：计时引爆摩天楼', type: 'movie', posterPath: '/poster.jpg' };
+        },
+        searchTV: async () => null
+    };
+    const service = new MediaLibraryLayoutService({ taskService: fakeTaskService, tmdbService: fakeTmdbService });
+    const libraryInfo = await service.resolveLibraryInfo({
+        resourceName: CONAN_TITLE,
+        files: CONAN_FILES,
+        task: null,
+        forceRefresh: true,
+        useAi: true
+    });
+    // 任务级锚定不应发生：文件夹名保留合集标题，tmdbId 为空
+    assert.equal(libraryInfo.tmdbId, '', '不应锚定到单一 TMDB 条目');
+    assert.equal(libraryInfo.mediaType, 'movie');
+    assert.ok(libraryInfo.resourceFolderName.includes('合集'), `文件夹名应含"合集": ${libraryInfo.resourceFolderName}`);
+    assert.ok(!libraryInfo.resourceFolderName.includes('计时引爆'), `文件夹名不应是单部标题: ${libraryInfo.resourceFolderName}`);
+    // 逐文件 TMDB 匹配应发生：files 数组存在且每条有 tmdbId
+    assert.ok(Array.isArray(libraryInfo.files), '应有 files 数组');
+    assert.equal(libraryInfo.files.length, CONAN_FILES.length);
+    assert.ok(libraryInfo.files.every((f) => f.tmdbId === '21422'), '每个文件应有 tmdbId');
+    assert.ok(searchedTitles.length > 0, '应触发逐文件 searchMovie');
+});
+
+test('normalizeLibraryInfo: 合集保留 files 数组，非合集省略', () => {
+    const service = new MediaLibraryLayoutService();
+    const files = [{ id: '1', name: 'x', tmdbId: '21422', tmdbTitle: 't', posterPath: '/p.jpg' }];
+    // 合集：files 应保留
+    const withFiles = service.normalizeLibraryInfo({ mediaType: 'movie', canonicalTitle: '合集', files });
+    assert.deepEqual(withFiles.files, files);
+    // 非合集：files 省略（不影响现有序列化）
+    const withoutFiles = service.normalizeLibraryInfo({ mediaType: 'movie', canonicalTitle: '单部电影' });
+    assert.equal(withoutFiles.files, undefined);
+    // 空 files 数组也省略
+    const emptyFiles = service.normalizeLibraryInfo({ mediaType: 'movie', canonicalTitle: 'x', files: [] });
+    assert.equal(emptyFiles.files, undefined);
+});
+
+test('确定性路径: 合集逐文件 TMDB 解析（useAi=false）', async () => {
+    const fakeTmdbService = {
+        searchMovie: async (title, year) => ({ id: 99999, title: `匹配:${title}`, posterPath: '/poster.jpg', type: 'movie' })
+    };
+    const service = new MediaLibraryLayoutService({ tmdbService: fakeTmdbService });
+    const libraryInfo = await service.resolveLibraryInfo({
+        resourceName: CONAN_TITLE,
+        files: CONAN_FILES,
+        task: null,
+        forceRefresh: true,
+        useAi: false // 走确定性分支
+    });
+    assert.equal(libraryInfo.mediaType, 'movie');
+    assert.ok(Array.isArray(libraryInfo.files), '确定性路径也应产出 files 数组');
+    assert.equal(libraryInfo.files.length, CONAN_FILES.length);
+    assert.ok(libraryInfo.files.every((f) => f.tmdbId === '99999'), '每个文件应有 tmdbId');
+    // 每个文件的 tmdbTitle 来自各自的独立标题
+    assert.ok(libraryInfo.files[0].tmdbTitle.startsWith('匹配:'), 'tmdbTitle 应来自逐文件搜索');
+});
+
+test('AI 分块: 超过 40 部的电影合集保留后续文件标题和年份', async () => {
+    const aiService = require('../src/services/ai');
+    const originalChat = aiService.chat;
+    const originalIsEnabled = aiService.isEnabled;
+
+    try {
+        aiService.isEnabled = () => true;
+        let callCount = 0;
+        aiService.chat = async () => ({
+            success: true,
+            data: JSON.stringify(++callCount === 1
+                ? {
+                    name: '电影合集', year: 2000, type: 'movie', season: '01',
+                    episode: Array.from({ length: 40 }, (_, index) => ({
+                        id: String(index + 1), name: `Film ${index + 1}`, year: 2000 + index,
+                        season: '01', episode: String(index + 1), extension: '.mkv'
+                    }))
+                }
+                : {
+                    episode: [
+                        { id: '41', name: 'Film 41', year: 2040, season: '01', episode: '41', extension: '.mkv' }
+                    ]
+                })
+        });
+
+        const result = await aiService.simpleChatCompletion(
+            '电影合集',
+            Array.from({ length: 41 }, (_, index) => ({
+                id: String(index + 1),
+                name: `Film.${index + 1}.${2000 + index}.mkv`
+            }))
+        );
+        const last = result.data.episode.find((episode) => episode.id === '41');
+
+        assert.equal(last.name, 'Film 41');
+        assert.equal(last.year, 2040);
+    } finally {
+        aiService.chat = originalChat;
+        aiService.isEnabled = originalIsEnabled;
+    }
+});

--- a/test/movieCollectionScrape.test.js
+++ b/test/movieCollectionScrape.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ScrapeService } = require('../src/services/ScrapeService');
+
+test('合集刮削以标题和年份区分同年电影', async () => {
+    const service = new ScrapeService();
+    service._getStrmFiles = async () => ['Beta (2020).strm', 'Alpha (2020).strm'];
+    service._parseStrmPath = () => ({ showDir: '/tmp' });
+    service._generateFileIfNotExists = async () => {};
+    const requestedIds = [];
+    service.tmdb.getMovieDetails = async (id) => {
+        requestedIds.push(String(id));
+        return { id, title: String(id), cast: [], posterPath: null };
+    };
+
+    const result = await service._scrapeCollection('/tmp', [
+        { name: 'Alpha', year: 2020, tmdbId: '1', organizedFileName: 'Alpha (2020).mkv' },
+        { name: 'Beta', year: 2020, tmdbId: '2', organizedFileName: 'Beta (2020).mkv' }
+    ]);
+
+    assert.deepEqual(requestedIds, ['1', '2']);
+    assert.equal(result.scraped, 2);
+});

--- a/test/settingsValidation.test.js
+++ b/test/settingsValidation.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { validateLazyFileCleanupSettings } = require('../src/utils/settingsValidation');
+
+test('懒转存清理设置允许自定义 Cron', () => {
+    assert.equal(validateLazyFileCleanupSettings({
+        task: {
+            lazyFileRetentionHours: 48,
+            lazyFileCleanupCron: '15 3 * * 1-5'
+        }
+    }), null);
+});
+
+test('懒转存清理设置拒绝小于 1 小时的保留时长', () => {
+    assert.equal(validateLazyFileCleanupSettings({
+        task: {
+            lazyFileRetentionHours: 0,
+            lazyFileCleanupCron: '0 3 * * *'
+        }
+    }), '懒转存文件保留时长不能小于 1 小时');
+});
+
+test('懒转存清理设置拒绝无效 Cron', () => {
+    assert.equal(validateLazyFileCleanupSettings({
+        task: {
+            lazyFileRetentionHours: 24,
+            lazyFileCleanupCron: '每天凌晨三点'
+        }
+    }), '懒转存清理 Cron 表达式无效');
+});

--- a/test/specialEpisode.test.js
+++ b/test/specialEpisode.test.js
@@ -1,0 +1,199 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { MediaLibraryLayoutService, isSpecialEpisodeName, pad2 } = require('../src/services/mediaLibraryLayout');
+
+describe('isSpecialEpisodeName', () => {
+    it('detects NCOP/NCED/SP/Non-Credit', () => {
+        assert.ok(isSpecialEpisodeName('[Group] Show [NCOP][1080p].mkv'));
+        assert.ok(isSpecialEpisodeName('[Group] Show [NCED03][1080p].mkv'));
+        assert.ok(isSpecialEpisodeName('[Group] Show [NCED][1080p].mkv'));
+        assert.ok(isSpecialEpisodeName('[Group] Show [SP01][1080p].mkv'));
+        assert.ok(isSpecialEpisodeName('[Group] Show [EP23 C-Part Non-Credit Ver.].mkv'));
+        assert.ok(isSpecialEpisodeName('[MAI] EIGHTY SIX [EP09 NCIN][Ma10p_2160p].mkv'));
+        assert.ok(isSpecialEpisodeName('[MAI] EIGHTY SIX [11.5][Ma10p_2160p][x265_flac_ass].mkv'));
+    });
+
+    it('does not false-positive on normal files', () => {
+        assert.ok(!isSpecialEpisodeName('Show.Name.S01E05.1080p.mkv'));
+        assert.ok(!isSpecialEpisodeName('[Group] Show [01][1080p].mkv'));
+        assert.ok(!isSpecialEpisodeName('Dispatched.Inspector.2024.mkv')); // \bSP\d must not match "sp" inside word
+        assert.ok(!isSpecialEpisodeName(''));
+        assert.ok(!isSpecialEpisodeName(null));
+    });
+});
+
+describe('buildRelativeDir union semantics', () => {
+    const svc = new MediaLibraryLayoutService();
+    const tvInfo = { seasonBased: true, mediaType: 'tv' };
+
+    it('trusts AI season 00 on non-regex name (OVA)', () => {
+        const dir = svc.buildRelativeDir(
+            { name: 'Show OVA.mkv' },
+            { season: '00', episode: '01' },
+            tvInfo
+        );
+        assert.equal(dir, 'Season 00');
+    });
+
+    it('safety net promotes NCOP even when AI says season 01', () => {
+        const dir = svc.buildRelativeDir(
+            { name: '[Group] Show [NCOP][1080p].mkv' },
+            { season: '01', episode: '17' },
+            tvInfo
+        );
+        assert.equal(dir, 'Season 00');
+    });
+
+    it('normal episodes trust AI season', () => {
+        assert.equal(svc.buildRelativeDir({ name: 'E01.mkv' }, { season: '01' }, tvInfo), 'Season 01');
+        assert.equal(svc.buildRelativeDir({ name: 'E01.mkv' }, { season: '2' }, tvInfo), 'Season 02');
+        assert.equal(svc.buildRelativeDir({ name: 'E01.mkv' }, { season: '00' }, tvInfo), 'Season 00');
+    });
+
+    it('falls back to parseMediaTitle when no aiFile', () => {
+        assert.equal(svc.buildRelativeDir({ name: 'Show.S02E05.mkv' }, null, tvInfo), 'Season 02');
+        assert.equal(svc.buildRelativeDir({ name: 'random.mkv' }, null, tvInfo), 'Season 01');
+    });
+});
+
+describe('buildFileName union semantics', () => {
+    const svc = new MediaLibraryLayoutService();
+    const tvInfo = { seasonBased: true, mediaType: 'tv' };
+    const resourceInfo = { name: 'Test Show', type: 'tv' };
+
+    it('NCED file with AI season 01 gets S00E in filename', () => {
+        const name = svc.buildFileName(
+            { name: '[Group] Test Show [NCED02][1080p].mkv' },
+            { season: '01', episode: '02', extension: '.mkv' },
+            resourceInfo,
+            tvInfo
+        );
+        assert.ok(name.includes('S00E'), `expected S00E in "${name}"`);
+        assert.ok(!name.includes('S01E'), `should not contain S01E in "${name}"`);
+    });
+
+    it('normal file keeps AI season', () => {
+        const name = svc.buildFileName(
+            { name: 'Test.Show.S01E05.mkv' },
+            { season: '01', episode: '05', extension: '.mkv' },
+            resourceInfo,
+            tvInfo
+        );
+        assert.ok(name.includes('S01E05'), `expected S01E05 in "${name}"`);
+    });
+});
+
+describe('simpleChatCompletion chunk-merge preserves per-file season', () => {
+    it('chunk 2 season 00 is not clobbered by baseResult season', async () => {
+        const aiService = require('../src/services/ai'); // singleton instance
+        const originalChat = aiService.chat.bind(aiService);
+        const originalIsEnabled = aiService.isEnabled.bind(aiService);
+
+        try {
+            aiService.isEnabled = () => true;
+            let callCount = 0;
+            aiService.chat = async () => {
+                callCount++;
+                if (callCount === 1) {
+                    // First chunk: base result + 40 episodes
+                    return {
+                        success: true,
+                        data: JSON.stringify({
+                            name: 'Test Show',
+                            year: 2024,
+                            type: 'tv',
+                            season: '01',
+                            episode: Array.from({ length: 40 }, (_, i) => ({
+                                id: String(i + 1),
+                                name: 'Test Show',
+                                season: '01',
+                                episode: String(i + 1).padStart(2, '0'),
+                                extension: '.mkv'
+                            }))
+                        })
+                    };
+                }
+                // Second chunk: 1 normal + 1 special (season 00)
+                return {
+                    success: true,
+                    data: JSON.stringify({
+                        episode: [
+                            { id: '41', name: 'Test Show', season: '01', episode: '41', extension: '.mkv' },
+                            { id: '42', name: 'Test Show', season: '00', episode: '01', extension: '.mkv' }
+                        ]
+                    })
+                };
+            };
+
+            const files = Array.from({ length: 42 }, (_, i) => ({
+                id: String(i + 1),
+                name: `Test.Show.${String(i + 1).padStart(2, '0')}.mkv`
+            }));
+
+            const result = await aiService.simpleChatCompletion('Test Show', files);
+            assert.ok(result.success, 'AI call should succeed');
+
+            const ep42 = result.data.episode.find(e => e.id === '42');
+            assert.ok(ep42, 'episode 42 should exist');
+            assert.equal(ep42.season, '00', 'chunk-2 special must keep season 00');
+            assert.equal(ep42.name, 'Test Show', 'name must be unified to baseResult');
+
+            const ep41 = result.data.episode.find(e => e.id === '41');
+            assert.equal(ep41.season, '01', 'chunk-2 normal keeps season 01');
+        } finally {
+            aiService.chat = originalChat;
+            aiService.isEnabled = originalIsEnabled;
+        }
+    });
+});
+
+describe('applyLayoutToFiles end-to-end', () => {
+    it('12 normal + NCOP + AI-flagged OVA → 12×S01 + 2×S00', () => {
+        const svc = new MediaLibraryLayoutService();
+        const libraryInfo = {
+            seasonBased: true,
+            mediaType: 'tv',
+            canonicalTitle: 'Test Show',
+            year: '2024',
+            categoryName: '动漫',
+            resourceFolderName: 'Test Show (2024)'
+        };
+        const resourceInfo = {
+            name: 'Test Show',
+            year: 2024,
+            type: 'tv',
+            episode: [
+                ...Array.from({ length: 12 }, (_, i) => ({
+                    id: String(i + 1),
+                    name: 'Test Show',
+                    season: '01',
+                    episode: String(i + 1).padStart(2, '0'),
+                    extension: '.mkv'
+                })),
+                { id: '13', name: 'Test Show', season: '01', episode: '13', extension: '.mkv' }, // NCOP, AI wrong
+                { id: '14', name: 'Test Show', season: '00', episode: '01', extension: '.mkv' }  // OVA, AI correct
+            ]
+        };
+        const files = [
+            ...Array.from({ length: 12 }, (_, i) => ({
+                id: String(i + 1),
+                name: `[Group] Test Show [${String(i + 1).padStart(2, '0')}][1080p].mkv`
+            })),
+            { id: '13', name: '[Group] Test Show [NCOP][1080p].mkv' },
+            { id: '14', name: '[Group] Test Show [OVA][1080p].mkv' }
+        ];
+
+        const result = svc.applyLayoutToFiles({
+            localStrmPrefix: '/strm',
+            libraryInfo,
+            resourceInfo,
+            files,
+            renameFiles: true
+        });
+
+        const s00 = result.files.filter(f => (f.relativeDir || '').includes('Season 00'));
+        const s01 = result.files.filter(f => (f.relativeDir || '').includes('Season 01'));
+        assert.equal(s01.length, 12, '12 normal episodes in Season 01');
+        assert.equal(s00.length, 2, 'NCOP + OVA in Season 00');
+    });
+});

--- a/test/taskExecution.test.js
+++ b/test/taskExecution.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { TaskService } = require('../src/services/task');
+
+test('重复触发同一任务时复用正在执行的 Promise', async () => {
+    const service = Object.create(TaskService.prototype);
+    service.activeTaskExecutions = new Map();
+    let executeCount = 0;
+    let releaseExecution;
+    const gate = new Promise((resolve) => {
+        releaseExecution = resolve;
+    });
+    service._processTaskInternal = async () => {
+        executeCount++;
+        await gate;
+        return '执行完成';
+    };
+
+    const first = service.processTask({ id: 1, resourceName: '测试任务' });
+    const second = service.processTask({ id: 1, resourceName: '测试任务' });
+    releaseExecution();
+
+    assert.deepEqual(await Promise.all([first, second]), ['执行完成', '执行完成']);
+    assert.equal(executeCount, 1);
+});
+
+test('可等待 createTask 保存的首次执行 Promise', async () => {
+    const service = Object.create(TaskService.prototype);
+    service.initialTaskExecutions = new WeakMap();
+    service.activeTaskExecutions = new Map();
+    const task = { id: 2 };
+    service.initialTaskExecutions.set(task, Promise.resolve('首次执行完成'));
+
+    assert.equal(await service.waitForInitialTaskExecution(task), '首次执行完成');
+});

--- a/test/templateRenderer.test.js
+++ b/test/templateRenderer.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderFileName, migrateTemplate } = require('../src/utils/templateRenderer');
+
+test('migrateTemplate: 旧电影模板迁移为条件渲染', () => {
+    assert.equal(migrateTemplate('{name} ({year}){ext}'), '{{name}}{% if year %} ({{year}}){% endif %}{{ext}}');
+});
+
+test('migrateTemplate: 旧剧集模板迁移', () => {
+    assert.equal(migrateTemplate('{name} - {se}{ext}'), '{{name}} - {{se}}{{ext}}');
+});
+
+test('renderFileName: 新格式条件渲染（有年份）', () => {
+    const result = renderFileName('{{name}}{% if year %} ({{year}}){% endif %}{{ext}}', { name: '柯南', year: 2006, ext: '.mkv' });
+    assert.equal(result, '柯南 (2006).mkv');
+});
+
+test('renderFileName: 新格式条件渲染（无年份不留空括号）', () => {
+    const result = renderFileName('{{name}}{% if year %} ({{year}}){% endif %}{{ext}}', { name: '柯南', year: '', ext: '.mkv' });
+    assert.equal(result, '柯南.mkv');
+});
+
+test('renderFileName: 剧集模板', () => {
+    const result = renderFileName('{{name}} - {{se}}{{ext}}', { name: '小圆', se: 'S01E08', ext: '.mkv' });
+    assert.equal(result, '小圆 - S01E08.mkv');
+});
+
+test('renderFileName: 旧格式自动迁移（电影有年份）', () => {
+    const result = renderFileName('{name} ({year}){ext}', { name: '柯南', year: 2006, ext: '.mkv' });
+    assert.equal(result, '柯南 (2006).mkv');
+});
+
+test('renderFileName: 旧格式自动迁移（电影无年份）', () => {
+    const result = renderFileName('{name} ({year}){ext}', { name: '柯南', year: '', ext: '.mkv' });
+    assert.equal(result, '柯南.mkv');
+});
+
+test('renderFileName: 旧格式自动迁移（剧集）', () => {
+    const result = renderFileName('{name} - {se}{ext}', { name: '小圆', se: 'S01E08', ext: '.mkv' });
+    assert.equal(result, '小圆 - S01E08.mkv');
+});
+
+test('renderFileName: 已是 nunjucks格式不二次迁移', () => {
+    const result = renderFileName('{{name}}{% if year %} ({{year}}){% endif %}{{ext}}', { name: '柯南', year:2006, ext: '.mkv' });
+    assert.equal(result, '柯南 (2006).mkv');
+});
+
+test('renderFileName: 模板语法错误回退简单拼接', () => {
+    const result = renderFileName('{{name} {% invalid %}', { name: '柯南', year: 2006, ext: '.mkv' });
+    assert.ok(result.includes('柯南'), `回退应含标题: ${result}`);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,6 +300,11 @@
   dependencies:
     "@types/node" "*"
 
+a-sync-waterfall@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmmirror.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz#75b6b6aa72598b497a125e7a2770f14f4c8a1fa7"
+  integrity sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.npmmirror.com/abbrev/-/abbrev-1.1.1.tgz"
@@ -351,6 +356,11 @@ aggregate-error@^3.0.0:
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
+
+anitomy-ng@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.npmmirror.com/anitomy-ng/-/anitomy-ng-1.0.7.tgz#b06b9abb0c3894a8bde2f89e730d26c33a85c0cc"
+  integrity sha512-em2HcweH+lCAq2zlq5Ap2vbAx4Ey/xxQXRHfIYJGPKxgFj+DmMKbdzBl6GFuFt4nONWwC/aaUv6oCok4xdbVWA==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -444,6 +454,11 @@ arraybuffer.prototype.slice@^1.0.4:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
+
+asap@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.npmmirror.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
 asn1.js@^5.4.1:
   version "5.4.1"
@@ -743,6 +758,11 @@ combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmmirror.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2199,6 +2219,15 @@ npmlog@^6.0.0:
     console-control-strings "^1.1.0"
     gauge "^4.0.3"
     set-blocking "^2.0.0"
+
+nunjucks@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.npmmirror.com/nunjucks/-/nunjucks-3.2.4.tgz#f0878eef528ce7b0aa35d67cc6898635fd74649e"
+  integrity sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==
+  dependencies:
+    a-sync-waterfall "^1.0.0"
+    asap "^2.0.3"
+    commander "^5.1.0"
 
 object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
## 变更内容

### 媒体识别与布局
- **动漫专用解析**：`mediaTitleParser` 引入 `anitomy-ng`，动漫风格文件名（`[字幕组][标题][集号][分辨率]` 等方括号堆叠）走专用解析器，标准点分命名仍走通用正则，互不干扰
- **电影合集**：`mediaLibraryLayout` 支持多部独立电影组成的合集逐文件 TMDB 匹配（PROMPT_VERSION v2），新增 `/api/tasks/:id/collection-files` 端点与前端合集详情入口
- **特别篇归季**：AI 主检测 + NCOP/NCED/SP 确定性兜底（全仓库唯一入口），特别篇归入 Season 00，不占正片集号；`ai.js` 分块识别不再强制覆盖逐文件 season
- **文件名模板**：新增 `templateRenderer`（nunjucks），支持自定义命名模板，语法错误回退简单拼接

### 修复
- Bangumi / 豆瓣 Top250 / AniBT / 图片代理四项媒体来源实测失败修复（806f980）
- 自动追剧来源断言补充 subscription（b3c912e）

### 其他
- 新增 `settingsValidation`（懒转存清理配置校验）
- 前端 TaskTab / SettingsTab / MediaTab / AutoSeriesTab 联动调整
- 测试：`node --test` 覆盖动漫解析、电影合集、特别篇、模板渲染、设置校验、任务执行，**49 项全部通过**

## 验证
```bash
node --test test/animeParser.test.js test/movieCollection.test.js test/movieCollectionScrape.test.js test/settingsValidation.test.js test/specialEpisode.test.js test/taskExecution.test.js test/templateRenderer.test.js
# pass 49 / fail 0
```